### PR TITLE
Align page styles to main page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -15,8 +15,8 @@ export const dynamic = 'force-static'
 
 export default function AboutPage() {
   return (
-    <div className='space-y-10'>
-      <section className='prose prose-invert max-w-none'>
+    <div className='space-y-12'>
+      <section className='prose prose-invert max-w-none prose-headings:font-display prose-headings:tracking-tight prose-headings:font-extrabold prose-h1:text-3xl md:prose-h1:text-4xl prose-h2:text-2xl md:prose-h2:text-3xl'>
         <h1>Über uns</h1>
         <p>
           Wir sind das Kolping-Open-Air-Theater Ramsen. Seit 2014 entwickeln wir
@@ -38,7 +38,7 @@ export default function AboutPage() {
       </section>
 
       <section className='space-y-4'>
-        <h2 className='text-2xl font-semibold'>Chronik</h2>
+        <h2 className='font-display text-2xl md:text-3xl font-extrabold tracking-tight'>Chronik</h2>
         <ol className='space-y-8'>
           {(timeline as unknown as TimelineEntry[])
             .slice()

--- a/src/app/gallery/[play]/page.tsx
+++ b/src/app/gallery/[play]/page.tsx
@@ -28,8 +28,8 @@ export default async function PlayGalleryPage({
   const title = show?.header ?? play
 
   return (
-    <div className='space-y-6'>
-      <h1 className='text-3xl font-bold'>{title}</h1>
+    <div className='space-y-12'>
+      <h1 className='font-display text-3xl md:text-4xl font-extrabold tracking-tight'>{title}</h1>
       <ClientGrid play={play} metas={metas} captions={captions} />
     </div>
   )

--- a/src/app/gallery/anno/page.tsx
+++ b/src/app/gallery/anno/page.tsx
@@ -1,7 +1,7 @@
 export default function AnnoGalleryComingSoon() {
   return (
-    <div className='space-y-6'>
-      <h1 className='text-3xl font-bold'>Anno 1146</h1>
+    <div className='space-y-12'>
+      <h1 className='font-display text-3xl md:text-4xl font-extrabold tracking-tight'>Anno 1146</h1>
       <div className='glass rounded-xl p-6 md:p-8'>
         <p className='text-site-100'>
           Die Galerie ist bald verfügbar. Schaut in der Zwischenzeit gerne auf unserer

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -15,8 +15,8 @@ export default function GalleryPage() {
     .filter((t) => t.image && t.galleryHash)
     .reverse()
   return (
-    <div className='space-y-6'>
-      <h1 className='text-3xl font-bold'>Galerie</h1>
+    <div className='space-y-12'>
+      <h1 className='font-display text-3xl md:text-4xl font-extrabold tracking-tight'>Galerie</h1>
       <div className='grid sm:grid-cols-2 lg:grid-cols-3 gap-4'>
         {shows.map((t: TimelineEntry) => (
           <Link

--- a/src/app/impressum/page.tsx
+++ b/src/app/impressum/page.tsx
@@ -2,9 +2,9 @@ export const dynamic = 'force-static'
 
 export default function ImpressumPage() {
   return (
-    <div className='space-y-8'>
-      <h1 className='text-3xl font-bold'>Impressum</h1>
-      <div className='rounded-lg border border-site-700 bg-site-800 p-4'>
+    <div className='space-y-12'>
+      <h1 className='font-display text-3xl md:text-4xl font-extrabold tracking-tight'>Impressum</h1>
+      <div className='glass rounded-xl p-6 md:p-8'>
         <div className='font-semibold mb-1'>Angaben gemäß § 5 TMG</div>
         <div>Johannes Stüber</div>
         <div>Fischerstraße 12</div>
@@ -20,7 +20,7 @@ export default function ImpressumPage() {
         </div>
       </div>
 
-      <section className='prose prose-invert max-w-none'>
+      <section className='prose prose-invert max-w-none prose-headings:font-display prose-headings:tracking-tight prose-headings:font-extrabold prose-h2:text-2xl md:prose-h2:text-3xl'>
         <h2>Haftung für Inhalte</h2>
         <ul className='list-disc pl-6 space-y-1'>
           <li>Eigene Inhalte nach § 7 Abs. 1 TMG, nach allgemeinen Gesetzen</li>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,10 +2,10 @@ export const dynamic = 'force-static'
 
 export default function PrivacyPage() {
   return (
-    <div className='space-y-8'>
-      <h1 className='text-3xl font-bold'>Datenschutz</h1>
+    <div className='space-y-12'>
+      <h1 className='font-display text-3xl md:text-4xl font-extrabold tracking-tight'>Datenschutz</h1>
       {/* Owner card */}
-      <div className='rounded-lg border border-site-700 bg-site-800 p-4'>
+      <div className='glass rounded-xl p-6 md:p-8'>
         <div className='font-semibold mb-1'>Verantwortlich für den Inhalt</div>
         <div>Johannes Stüber</div>
         <div>Fischerstraße 12</div>
@@ -21,7 +21,7 @@ export default function PrivacyPage() {
         </div>
       </div>
 
-      <section className='prose prose-invert max-w-none'>
+      <section className='prose prose-invert max-w-none prose-headings:font-display prose-headings:tracking-tight prose-headings:font-extrabold prose-h2:text-2xl md:prose-h2:text-3xl'>
         <h2>Allgemeines</h2>
         <p>
           Nachfolgend informieren wir über die Verarbeitung personenbezogener

--- a/src/app/team/[person]/page.tsx
+++ b/src/app/team/[person]/page.tsx
@@ -69,7 +69,7 @@ export default async function PersonPage({
     : `/img/team/avatar/${person.id}.jpg`
 
   return (
-    <div className='space-y-8'>
+    <div className='space-y-12'>
       <div className='grid md:grid-cols-[320px_1fr] gap-8 items-start'>
         <div className='space-y-4'>
           <Slideshow
@@ -81,7 +81,7 @@ export default async function PersonPage({
         </div>
         <div className='space-y-4'>
           <div>
-            <h1 className='text-3xl font-bold'>{person.name ?? person.id}</h1>
+            <h1 className='font-display text-3xl md:text-4xl font-extrabold tracking-tight'>{person.name ?? person.id}</h1>
             <p className='text-site-100'>Mitglied des Kolpingtheaters</p>
           </div>
           {person.roles ? (

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -37,9 +37,9 @@ export default function TeamPage() {
   ).tech
 
   return (
-    <div className='space-y-10'>
+    <div className='space-y-12'>
       <div>
-        <h1 className='text-3xl font-bold mb-4'>Ensemble</h1>
+        <h1 className='font-display text-3xl md:text-4xl font-extrabold tracking-tight mb-4'>Ensemble</h1>
         <div className='grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6'>
           {current.map((p: Person) => (
             <Link
@@ -68,7 +68,7 @@ export default function TeamPage() {
       </div>
 
       <div>
-        <h2 className='text-2xl font-semibold mb-4'>Technik & Crew</h2>
+        <h2 className='font-display text-2xl md:text-3xl font-extrabold tracking-tight mb-4'>Technik & Crew</h2>
         <div className='grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6'>
           {tech.map((t) => (
             <Link
@@ -122,7 +122,7 @@ export default function TeamPage() {
       </div>
 
       <div>
-        <h2 className='text-2xl font-semibold mb-4'>Ehemalige</h2>
+        <h2 className='font-display text-2xl md:text-3xl font-extrabold tracking-tight mb-4'>Ehemalige</h2>
         <div className='grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4'>
           {former.map((p: Person) => (
             <Link


### PR DESCRIPTION
Align subpage typography, spacing, and card styles with the main page for visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0e64b72-eb16-46ae-a85b-6eea25be07dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f0e64b72-eb16-46ae-a85b-6eea25be07dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

