### PR TITLE
Fix main page mobile responsiveness

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,6 +43,12 @@ export const metadata: Metadata = {
     icon: ['/favicon.svg'],
     apple: ['/img/logo.png'],
   },
+  viewport: 'width=device-width, initial-scale=1',
+}
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
 }
 
 export default function RootLayout({
@@ -53,7 +59,7 @@ export default function RootLayout({
   return (
     <html lang='de' data-theme='dark' suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${display.variable} antialiased bg-site-900 text-site-50 min-h-screen flex flex-col`}
+        className={`${geistSans.variable} ${geistMono.variable} ${display.variable} antialiased bg-site-900 text-site-50 min-h-screen overflow-x-hidden flex flex-col`}
       >
         <Header />
         <main className='mx-auto max-w-6xl px-4 py-8 flex-1'>{children}</main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,7 +60,7 @@ export default function Home() {
               Ob Schauspiel, Technik oder Organisation – bei uns ist Platz für alle, die Theater lieben.
             </p>
           </div>
-          <div className='flex items-center gap-3'>
+          <div className='flex flex-wrap items-center gap-3'>
             <a
               href='https://www.instagram.com/kolpingjugend_ramsen/'
               target='_blank'

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,7 +11,7 @@ export default function Header() {
   return (
     <header className='sticky top-0 z-50 backdrop-blur supports-[backdrop-filter]:bg-site-900/80 bg-site-900/95 border-b border-site-700'>
       <div className='mx-auto max-w-6xl px-4 py-3 flex items-center gap-4'>
-        <Link href='/' className='flex items-center gap-2 font-semibold text-site-50'>
+        <Link href='/' className='flex items-center gap-2 font-semibold text-site-50 flex-1 min-w-0'>
           <Image
             src='/img/logo.png'
             alt='Kolpingtheater Ramsen'
@@ -19,7 +19,7 @@ export default function Header() {
             height={36}
             className='rounded-sm'
           />
-          <span>Kolpingtheater Ramsen</span>
+          <span className='truncate'>Kolpingtheater Ramsen</span>
         </Link>
         <nav className='ml-auto hidden md:flex items-center gap-6 text-sm'>
           <Link href='/' className='hover:text-kolping-400'>


### PR DESCRIPTION
Improve mobile responsiveness of the main page by adding viewport settings, preventing overflow, and adjusting layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-d09f6eef-f3ae-418c-b277-fd1e61a6ca85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d09f6eef-f3ae-418c-b277-fd1e61a6ca85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

