### PR TITLE
Fix layout overflow on small screens

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -52,6 +52,7 @@
 html,
 body {
   min-height: 100%;
+  overflow-x: hidden; /* Prevent horizontal scroll caused by wide transforms/effects */
 }
 
 ::selection {


### PR DESCRIPTION
Add `overflow-x: hidden` to `html, body` to prevent horizontal scrolling on small screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-007c3d56-1455-4c56-b099-d30028006057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-007c3d56-1455-4c56-b099-d30028006057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

