### PR TITLE
Admin show seat availability chart and booking nav

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -318,6 +318,66 @@ export default function AdminDashboardPage() {
         </div>
       </div>
 
+      {/* Seats Available per Show Chart */}
+      {plays.length > 0 && (
+        <div className='glass rounded-xl p-6 mb-8'>
+          <h2 className='text-xl font-display font-bold mb-6'>Verfügbare Plätze pro Vorstellung</h2>
+          <div className='space-y-4'>
+            {plays.map((play) => {
+              const availablePercent = (play.available_seats / play.total_seats) * 100
+              const bookedPercent = 100 - availablePercent
+              
+              return (
+                <div key={play.id} className='group'>
+                  <div className='flex justify-between items-center mb-2'>
+                    <span className='text-sm font-medium truncate mr-4'>{play.display_date}</span>
+                    <span className='text-sm text-site-100 whitespace-nowrap'>
+                      {play.available_seats} / {play.total_seats} verfügbar
+                    </span>
+                  </div>
+                  <div className='relative h-8 bg-site-800 rounded-lg overflow-hidden border border-site-700'>
+                    {/* Booked seats (background) */}
+                    <div
+                      className='absolute inset-y-0 left-0 bg-gradient-to-r from-kolping-600 to-kolping-500 transition-all duration-500 ease-out'
+                      style={{ width: `${bookedPercent}%` }}
+                    />
+                    {/* Available seats indicator */}
+                    <div
+                      className='absolute inset-y-0 right-0 bg-gradient-to-r from-green-600/80 to-green-500/80 transition-all duration-500 ease-out'
+                      style={{ width: `${availablePercent}%` }}
+                    />
+                    {/* Labels inside bar */}
+                    <div className='absolute inset-0 flex items-center justify-between px-3 text-xs font-semibold'>
+                      <span className={`${bookedPercent > 15 ? 'text-white' : 'text-transparent'}`}>
+                        {play.booked_seats} gebucht
+                      </span>
+                      <span className={`${availablePercent > 15 ? 'text-white' : 'text-transparent'}`}>
+                        {play.available_seats} frei
+                      </span>
+                    </div>
+                  </div>
+                  {/* Sold out indicator */}
+                  {play.is_sold_out && (
+                    <p className='text-xs text-red-400 mt-1 font-semibold'>⚠️ Ausverkauft</p>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+          {/* Legend */}
+          <div className='flex flex-wrap justify-center gap-6 mt-6 pt-4 border-t border-site-700'>
+            <div className='flex items-center gap-2'>
+              <div className='w-4 h-4 rounded bg-gradient-to-r from-kolping-600 to-kolping-500' />
+              <span className='text-sm text-site-100'>Gebucht</span>
+            </div>
+            <div className='flex items-center gap-2'>
+              <div className='w-4 h-4 rounded bg-gradient-to-r from-green-600/80 to-green-500/80' />
+              <span className='text-sm text-site-100'>Verfügbar</span>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Seat Map Stats */}
       {selectedPlayId !== 'all' && (
         <div className='glass rounded-xl p-6 mb-6'>

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -190,6 +190,8 @@ export default function BookingPage() {
             <div className='grid gap-4 md:grid-cols-2'>
               {plays.map((play) => {
                 const isSoldOut = play.is_sold_out
+                const availablePercent = isMounted ? (play.available_seats / play.total_seats) * 100 : 100
+                const bookedPercent = 100 - availablePercent
 
                 return (
                   <button
@@ -203,7 +205,7 @@ export default function BookingPage() {
                     }`}
                   >
                     <div className='text-lg font-semibold mb-2'>{play.display_date}</div>
-                    <div className='text-site-100'>
+                    <div className='text-site-100 text-sm mb-3'>
                       {isMounted && isSoldOut ? (
                         <span className='text-red-400'>Ausverkauft</span>
                       ) : (
@@ -211,6 +213,17 @@ export default function BookingPage() {
                           {isMounted ? `${play.available_seats} von ${play.total_seats} Plätzen verfügbar` : `${play.total_seats} von ${play.total_seats} Plätzen verfügbar`}
                         </span>
                       )}
+                    </div>
+                    {/* Availability bar */}
+                    <div className='relative h-2 bg-site-700 rounded-full overflow-hidden'>
+                      <div
+                        className='absolute inset-y-0 left-0 bg-kolping-500 rounded-full transition-all duration-500'
+                        style={{ width: `${bookedPercent}%` }}
+                      />
+                      <div
+                        className='absolute inset-y-0 right-0 bg-green-500 rounded-full transition-all duration-500'
+                        style={{ width: `${availablePercent}%` }}
+                      />
                     </div>
                   </button>
                 )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,9 +25,9 @@ export default function Header() {
           <Link href='/' className='hover:text-kolping-400 focus:outline-none focus:ring-2 focus:ring-kolping-400 focus:ring-offset-2 focus:ring-offset-site-900 rounded px-1 transition-colors'>
             Home
           </Link>
-          {/* <Link href='/booking' className='hover:text-kolping-400 focus:outline-none focus:ring-2 focus:ring-kolping-400 focus:ring-offset-2 focus:ring-offset-site-900 rounded px-1 transition-colors'>
+          <Link href='/booking' className='hover:text-kolping-400 focus:outline-none focus:ring-2 focus:ring-kolping-400 focus:ring-offset-2 focus:ring-offset-site-900 rounded px-1 transition-colors'>
             Tickets
-          </Link> */}
+          </Link>
           <Link href='/about' className='hover:text-kolping-400 focus:outline-none focus:ring-2 focus:ring-kolping-400 focus:ring-offset-2 focus:ring-offset-site-900 rounded px-1 transition-colors'>
             Über uns
           </Link>
@@ -78,9 +78,9 @@ export default function Header() {
             <Link href='/' className='hover:text-kolping-400 focus:outline-none focus:ring-2 focus:ring-kolping-400 rounded px-1 transition-colors' onClick={() => setIsMobileOpen(false)}>
               Home
             </Link>
-            {/* <Link href='/booking' className='hover:text-kolping-400 focus:outline-none focus:ring-2 focus:ring-kolping-400 rounded px-1 transition-colors' onClick={() => setIsMobileOpen(false)}>
+            <Link href='/booking' className='hover:text-kolping-400 focus:outline-none focus:ring-2 focus:ring-kolping-400 rounded px-1 transition-colors' onClick={() => setIsMobileOpen(false)}>
               Tickets
-            </Link> */}
+            </Link>
             <Link href='/about' className='hover:text-kolping-400 focus:outline-none focus:ring-2 focus:ring-kolping-400 rounded px-1 transition-colors' onClick={() => setIsMobileOpen(false)}>
               Über uns
             </Link>


### PR DESCRIPTION
Add a bar chart to the admin dashboard showing seat availability per show and enable the booking link in the navigation bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-601087d8-ca1c-4a3f-8651-23247df7cd78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-601087d8-ca1c-4a3f-8651-23247df7cd78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds seat availability bar chart to the admin dashboard, availability bars to booking cards, and enables the Tickets link in navigation.
> 
> - **Admin Dashboard (`src/app/admin/dashboard/page.tsx`)**:
>   - **Seat availability chart**: Visual bar per `play` showing booked vs available percentages with labels, sold-out indicator, and legend.
> - **Booking Page (`src/app/booking/page.tsx`)**:
>   - **Availability bars**: Adds compact progress bars on play cards indicating booked vs available seats; minor text styling tweaks.
> - **Navigation (`src/components/Header.tsx`)**:
>   - **Enable Tickets link**: Activates `Link` to `/booking` in desktop and mobile menus.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b2145ffb4c22d914808b668a1d56142f200d87d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->