### PR TITLE
Overlay gallery text for consistent card height

### DIFF
--- a/src/app/gallery/[play]/ClientGrid.tsx
+++ b/src/app/gallery/[play]/ClientGrid.tsx
@@ -32,7 +32,7 @@ export default function ClientGrid({
           return (
             <button
               key={i}
-              className='group inline-block w-full mb-5 md:mb-6 break-inside-avoid text-left poster-frame border-epic transition-all duration-500 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-kolping-500 focus:ring-offset-2 focus:ring-offset-site-900'
+              className='group inline-block w-full mb-5 md:mb-6 break-inside-avoid text-left poster-frame border-epic overflow-hidden transition-all duration-500 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-kolping-500 focus:ring-offset-2 focus:ring-offset-site-900'
               onClick={() => setOpenIndex(i)}
               style={{ 
                 viewTransitionName: `photo-${play}-${i}`,
@@ -51,19 +51,20 @@ export default function ClientGrid({
                   sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
                 />
                 
-                {/* Overlay gradient for caption readability */}
-                <div className='absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/80 via-black/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-10' />
+                {/* Gradient overlay for caption - always visible but subtle, stronger on hover */}
+                <div className='absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/90 via-black/40 to-transparent opacity-60 group-hover:opacity-90 transition-opacity duration-500 z-10' />
                 
-                {/* Hover caption overlay */}
-                <div className='absolute inset-x-0 bottom-0 p-3 text-xs text-white font-medium opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-y-2 group-hover:translate-y-0 z-20'>
-                  Klicken zum Vergrößern
+                {/* Caption overlay - always visible at bottom */}
+                <div className='absolute inset-x-0 bottom-0 p-3 sm:p-4 z-20'>
+                  <p className='text-xs sm:text-sm text-white/90 font-medium line-clamp-2 drop-shadow-lg transition-all duration-300 group-hover:text-white'>
+                    {captions[i] ?? m.alt}
+                  </p>
+                  
+                  {/* Hover hint */}
+                  <span className='block mt-1.5 text-[10px] text-kolping-400/80 font-medium opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-y-1 group-hover:translate-y-0'>
+                    Klicken zum Vergrößern
+                  </span>
                 </div>
-              </div>
-              
-              <div className='relative p-3 sm:p-4 bg-gradient-to-b from-site-800 to-site-900 border-t border-site-700 group-hover:border-kolping-500/50 transition-colors duration-300'>
-                <p className='text-xs sm:text-sm text-site-100 line-clamp-2 group-hover:text-site-50 transition-colors duration-300'>
-                  {captions[i] ?? m.alt}
-                </p>
               </div>
             </button>
           )

--- a/src/app/gallery/[play]/ClientGrid.tsx
+++ b/src/app/gallery/[play]/ClientGrid.tsx
@@ -51,19 +51,21 @@ export default function ClientGrid({
                   sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
                 />
                 
-                {/* Gradient overlay for caption - always visible but subtle, stronger on hover */}
-                <div className='absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/90 via-black/40 to-transparent opacity-60 group-hover:opacity-90 transition-opacity duration-500 z-10' />
+                {/* Gradient overlay for caption */}
+                <div className='absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/95 via-black/40 to-transparent z-10' />
                 
-                {/* Caption overlay - always visible at bottom */}
-                <div className='absolute inset-x-0 bottom-0 p-3 sm:p-4 z-20'>
-                  <p className='text-xs sm:text-sm text-white/90 font-medium line-clamp-2 drop-shadow-lg transition-all duration-300 group-hover:text-white'>
-                    {captions[i] ?? m.alt}
-                  </p>
-                  
-                  {/* Hover hint */}
-                  <span className='block mt-1.5 text-[10px] text-kolping-400/80 font-medium opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-y-1 group-hover:translate-y-0'>
-                    Klicken zum Vergrößern
-                  </span>
+                {/* Caption overlay with backdrop for guaranteed readability */}
+                <div className='absolute inset-x-0 bottom-0 z-20'>
+                  <div className='p-3 sm:p-4 bg-black/60 backdrop-blur-sm'>
+                    <p className='text-xs sm:text-sm text-white font-medium line-clamp-2 transition-all duration-300' style={{ textShadow: '0 1px 3px rgba(0,0,0,0.8)' }}>
+                      {captions[i] ?? m.alt}
+                    </p>
+                    
+                    {/* Hover hint */}
+                    <span className='block mt-1.5 text-[10px] text-kolping-400 font-medium opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-y-1 group-hover:translate-y-0'>
+                      Klicken zum Vergrößern
+                    </span>
+                  </div>
                 </div>
               </div>
             </button>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -51,25 +51,28 @@ export default function GalleryPage() {
                 }}
               />
               
-              {/* Gradient overlay for text readability - enhanced for text overlay */}
-              <div className='absolute inset-0 bg-gradient-to-t from-black via-black/50 to-transparent opacity-70 group-hover:opacity-80 transition-opacity duration-500 z-10' />
+              {/* Gradient overlay for text readability */}
+              <div className='absolute inset-0 bg-gradient-to-t from-black/95 via-black/30 to-transparent z-10' />
               
-              {/* Text overlay positioned at bottom */}
-              <div className='absolute inset-x-0 bottom-0 p-4 sm:p-5 z-20'>
-                <div className='space-y-2'>
-                  <h2 className='font-display text-lg sm:text-xl font-bold text-white drop-shadow-lg transition-all duration-300 group-hover:text-kolping-400 group-hover:translate-x-1'>
-                    {t.header}
-                  </h2>
-                  <div className='flex items-center justify-between'>
-                    <span className='text-xs sm:text-sm text-white/80 font-mono drop-shadow-md'>{t.date}</span>
-                    <svg 
-                      className='w-5 h-5 text-kolping-400 drop-shadow-lg transition-transform duration-300 group-hover:translate-x-2' 
-                      fill='none' 
-                      viewBox='0 0 24 24' 
-                      stroke='currentColor'
-                    >
-                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M13 7l5 5m0 0l-5 5m5-5H6' />
-                    </svg>
+              {/* Text overlay positioned at bottom with backdrop */}
+              <div className='absolute inset-x-0 bottom-0 z-20'>
+                <div className='p-4 sm:p-5 bg-black/60 backdrop-blur-sm'>
+                  <div className='space-y-2'>
+                    <h2 className='font-display text-lg sm:text-xl font-bold text-white transition-all duration-300 group-hover:text-kolping-400 group-hover:translate-x-1' style={{ textShadow: '0 2px 4px rgba(0,0,0,0.8)' }}>
+                      {t.header}
+                    </h2>
+                    <div className='flex items-center justify-between'>
+                      <span className='text-xs sm:text-sm text-white/90 font-mono' style={{ textShadow: '0 1px 2px rgba(0,0,0,0.8)' }}>{t.date}</span>
+                      <svg 
+                        className='w-5 h-5 text-kolping-400 transition-transform duration-300 group-hover:translate-x-2' 
+                        fill='none' 
+                        viewBox='0 0 24 24' 
+                        stroke='currentColor'
+                        style={{ filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.5))' }}
+                      >
+                        <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M13 7l5 5m0 0l-5 5m5-5H6' />
+                      </svg>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -31,7 +31,7 @@ export default function GalleryPage() {
           <Link
             key={t.galleryHash}
             href={`/gallery/${t.galleryHash}`}
-            className='group poster-frame tilt border-epic bg-site-800 transition-all duration-500 hover:scale-[1.02]'
+            className='group relative poster-frame tilt border-epic overflow-hidden transition-all duration-500 hover:scale-[1.02]'
             aria-label={`Galerie ansehen: ${t.header}`}
             style={{ 
               viewTransitionName: `gallery-${t.galleryHash}`,
@@ -39,7 +39,6 @@ export default function GalleryPage() {
           >
             <div className='relative aspect-[3/4] overflow-hidden bg-gradient-to-b from-site-700 to-site-900'>
               {/* Spotlight effect overlay */}
-              <div className='absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/60 z-10 pointer-events-none' />
               <div className='spotlight' />
               
               <Image
@@ -52,25 +51,26 @@ export default function GalleryPage() {
                 }}
               />
               
-              {/* Gradient overlay for text readability */}
-              <div className='absolute inset-0 bg-gradient-to-t from-black/90 via-black/20 to-transparent z-10' />
-            </div>
-            
-            <div className='relative p-4 sm:p-5 bg-gradient-to-b from-site-800 to-site-900 border-t border-site-700'>
-              <div className='space-y-2'>
-                <h2 className='font-display text-lg sm:text-xl font-bold text-kolping-400 transition-all duration-300 group-hover:text-kolping-500 group-hover:translate-x-1'>
-                  {t.header}
-                </h2>
-                <div className='flex items-center justify-between'>
-                  <span className='text-xs sm:text-sm text-site-100 font-mono'>{t.date}</span>
-                  <svg 
-                    className='w-5 h-5 text-kolping-500 transition-transform duration-300 group-hover:translate-x-2' 
-                    fill='none' 
-                    viewBox='0 0 24 24' 
-                    stroke='currentColor'
-                  >
-                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M13 7l5 5m0 0l-5 5m5-5H6' />
-                  </svg>
+              {/* Gradient overlay for text readability - enhanced for text overlay */}
+              <div className='absolute inset-0 bg-gradient-to-t from-black via-black/50 to-transparent opacity-70 group-hover:opacity-80 transition-opacity duration-500 z-10' />
+              
+              {/* Text overlay positioned at bottom */}
+              <div className='absolute inset-x-0 bottom-0 p-4 sm:p-5 z-20'>
+                <div className='space-y-2'>
+                  <h2 className='font-display text-lg sm:text-xl font-bold text-white drop-shadow-lg transition-all duration-300 group-hover:text-kolping-400 group-hover:translate-x-1'>
+                    {t.header}
+                  </h2>
+                  <div className='flex items-center justify-between'>
+                    <span className='text-xs sm:text-sm text-white/80 font-mono drop-shadow-md'>{t.date}</span>
+                    <svg 
+                      className='w-5 h-5 text-kolping-400 drop-shadow-lg transition-transform duration-300 group-hover:translate-x-2' 
+                      fill='none' 
+                      viewBox='0 0 24 24' 
+                      stroke='currentColor'
+                    >
+                      <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M13 7l5 5m0 0l-5 5m5-5H6' />
+                    </svg>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Overlay gallery card text on images to ensure consistent card heights.

This change prevents height inconsistencies caused by multi-line text by integrating text directly into the image area with gradient overlays and hover effects, removing the separate text containers.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab591dbc-28ef-456d-9d72-f83ccb2b84cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab591dbc-28ef-456d-9d72-f83ccb2b84cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move captions into on-image overlays with gradients/backdrop blur for consistent card heights and improved readability across gallery and photo grids.
> 
> - **UI overlays and layout**:
>   - `src/app/gallery/page.tsx`:
>     - Overlay title/date on image with gradient and `bg-black/60` backdrop blur; remove separate text container.
>     - Strengthen readability: `from-black/95` gradient, white text, hover color/translate, drop-shadow on icon.
>     - Card wrapper tweaks: add `relative` and `overflow-hidden` to `Link`.
>   - `src/app/gallery/[play]/ClientGrid.tsx`:
>     - Overlay captions and hover hint on thumbnails with gradient and backdrop blur; remove bottom caption section.
>     - Add `overflow-hidden` to button/card; enhance hover visual (spotlight, scale/brightness).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28a7272b99c4e402b07a804cc911846c1025a1ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->