### PR TITLE
Crew page mislabeling correction

### DIFF
--- a/src/data/team.json
+++ b/src/data/team.json
@@ -12,7 +12,7 @@
     "2024 “Nexus”",
     "2024 “Eine höllische Herausforderung” (Kreativbühne)",
     "2025 “Anno 1146”",
-    "2025 “Schicksalsfäden”"
+    "2025 “Schicksalsfäden” (Kreativbühne)"
   ],
   "slugs": [
     null,


### PR DESCRIPTION
Add "(Kreativbühne)" to "Schicksalsfäden" in `team.json` because it was incorrectly listed as an Open Air stage on the crew page.

---
<a href="https://cursor.com/background-agent?bcId=bc-dcf44041-4ba7-4fae-98dc-cbcbc8c4dffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dcf44041-4ba7-4fae-98dc-cbcbc8c4dffa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `src/data/team.json` to label 2025 “Schicksalsfäden” as “(Kreativbühne)”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 595f783d99f7903d44b51ee72580c66c02bd4902. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->