### PR TITLE
Main page tag contrast

### DIFF
--- a/src/components/FeaturedProductions.tsx
+++ b/src/components/FeaturedProductions.tsx
@@ -25,7 +25,7 @@ export default function FeaturedProductions({ items }: { items: Item[] }) {
               />
               <div className='absolute left-2 top-2 z-10 flex items-center gap-1.5'>
                 {item.tag ? (
-                  <span className='rounded bg-kolping-400 px-2 py-[2px] text-[11px] font-bold uppercase text-black'>
+                  <span className='rounded bg-kolping-400 px-2 py-[2px] text-[11px] font-bold uppercase text-white'>
                     {item.tag}
                   </span>
                 ) : null}


### PR DESCRIPTION
Change tag text color to white to improve contrast in light mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-53cd5d7d-4d06-41b1-8a7d-c85fada63122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53cd5d7d-4d06-41b1-8a7d-c85fada63122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change the `item.tag` badge text color from black to white in `src/components/FeaturedProductions.tsx` to improve contrast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ead0fd2a3ee0c06f141fb5c86cdacf96e1b65f41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->