### PR TITLE
Redesign landing page with cinematic editorial layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import FeaturedProductions from '@/components/FeaturedProductions'
 import Image from 'next/image'
 import Link from 'next/link'
 import teamData from '@/data/team.json'
+import timeline from '@/data/timeline.json'
 
 export default function Home() {
   const marqueeItems = teamData.plays.map((p) => ({
@@ -15,112 +16,241 @@ export default function Home() {
     .filter((p) => p.gallery)
     .reverse()
     .slice(0, 6)
-    .map((p, idx) => ({
-      title: p.play,
-      image: `/img/banners/${p.slug}.jpg`,
-      href: `/gallery/${p.slug}`,
-      tag: idx === 0 ? 'Neu' : undefined,
-      year: p.year,
-      location: p.location,
-    }))
-  return (
-    <div className='space-y-8 sm:space-y-10 md:space-y-12'>
-      {/* Hero Section - Schicksalsfäden */}
-      <section className='mx-auto w-full max-w-6xl space-y-6'>
-        <div className='relative overflow-hidden rounded-xl border border-site-700 bg-site-900'>
-          <div className='relative w-full flex items-center justify-center bg-site-900'>
-            {/* Blurred background cover */}
-            <Image
-              src='/img/home_team.jpg'
-              alt=''
-              width={1200}
-              height={675}
-              priority
-              sizes='(max-width: 768px) 100vw, 1152px'
-              className='absolute inset-0 w-full h-full object-cover blur-xl opacity-50'
-              aria-hidden='true'
-            />
-            {/* Sharp foreground contain */}
-            <Image
-              src='/img/home_team.jpg'
-              alt='Schicksalsfäden - Winterstück 2025'
-              width={1200}
-              height={675}
-              priority
-              sizes='(max-width: 768px) 100vw, 1152px'
-              className='relative w-full h-auto md:max-h-[600px] lg:max-h-[750px] object-contain z-10'
-            />
-          </div>
-        </div>
+    .map((p, idx) => {
+      const entry = timeline.find((t) => 'galleryHash' in t && t.galleryHash === p.slug)
+      return {
+        title: p.play,
+        image: `/img/banners/${p.slug}.jpg`,
+        href: `/gallery/${p.slug}`,
+        tag: idx === 0 ? 'Neu' : undefined,
+        year: p.year,
+        location: p.location,
+        dominantColor: entry && 'dominantColor' in entry ? entry.dominantColor : '#0a0a0a',
+      }
+    })
 
-        {/* Text content container */}
-        <div className='glass rounded-xl p-6 md:p-8'>
-          <div className='mb-1 sm:mb-2 text-[10px] sm:text-xs md:text-sm font-semibold tracking-[0.15em] sm:tracking-[0.2em] text-kolping-400 uppercase'>
-            2025 - Aufführungen beendet
-          </div>
-          <h1 className='font-display text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-black tracking-tight'>
-            Schicksalsfäden
-          </h1>
-          <p className='mt-3 sm:mt-4 text-sm sm:text-base md:text-lg text-site-100 max-w-2xl'>
-            Eine Tragödie, inspiriert von den griechischen Schicksalsgöttinnen, den Moiren.
-          </p>
-          <div className='mt-8 p-6 glass rounded-lg border-l-4 border-kolping-500 bg-site-800/50'>
-            <h3 className='text-xl font-bold text-white mb-2'>Vielen Dank!</h3>
-            <p className='text-site-100'>
-              Die Aufführungen sind vorüber. Wir bedanken uns herzlich bei allen Besuchern für den großen Zuspruch und die tolle Stimmung! Bis zum nächsten Mal.
-            </p>
+  const productionCount = teamData.plays.length
+  const yearsActive = new Date().getFullYear() - 2014
+
+  return (
+    <div className='space-y-0'>
+      {/* === HERO === Full-bleed cinematic hero */}
+      <section className='relative -mx-4 -mt-8 overflow-hidden'>
+        {/* Background image with Ken Burns */}
+        <div className='relative w-full h-[85vh] min-h-[500px] max-h-[900px]'>
+          <Image
+            src='/img/home_team.jpg'
+            alt='Schicksalsfäden - Winterstück 2025'
+            fill
+            priority
+            sizes='100vw'
+            className='object-cover animate-kenburns'
+          />
+          {/* Cinematic overlays */}
+          <div className='absolute inset-0 bg-gradient-to-b from-site-950/40 via-transparent to-site-950' />
+          <div className='absolute inset-0 bg-gradient-to-r from-site-950/60 via-transparent to-site-950/30' />
+          <div className='vignette' />
+
+          {/* Hero content - editorial layout */}
+          <div className='absolute inset-0 flex flex-col justify-end pb-12 sm:pb-16 md:pb-20'>
+            <div className='mx-auto w-full max-w-6xl px-4'>
+              {/* Status badge */}
+              <div className='animate-fade-in-up mb-4' style={{ animationDelay: '0.1s' }}>
+                <span className='inline-flex items-center gap-2 rounded-full border border-kolping-400/40 bg-site-950/60 backdrop-blur-sm px-4 py-1.5 text-[11px] sm:text-xs font-semibold tracking-[0.2em] text-kolping-400 uppercase'>
+                  <span className='w-1.5 h-1.5 rounded-full bg-kolping-400 animate-glow-pulse' />
+                  2025 &middot; Kreativbühne
+                </span>
+              </div>
+
+              {/* Title - massive editorial typography */}
+              <h1
+                className='animate-fade-in-up font-display text-5xl sm:text-6xl md:text-7xl lg:text-8xl xl:text-9xl font-black tracking-tight leading-[0.9] text-shadow-lg'
+                style={{ animationDelay: '0.2s' }}
+              >
+                Schicksals
+                <br />
+                <span className='text-kolping-400'>fäden</span>
+              </h1>
+
+              {/* Subtitle */}
+              <p
+                className='animate-fade-in-up mt-4 sm:mt-6 text-base sm:text-lg md:text-xl text-site-100/90 max-w-xl leading-relaxed text-shadow'
+                style={{ animationDelay: '0.35s' }}
+              >
+                Eine Tragödie, inspiriert von den griechischen
+                Schicksalsgöttinnen, den Moiren.
+              </p>
+
+              {/* CTA row */}
+              <div
+                className='animate-fade-in-up mt-6 sm:mt-8 flex flex-wrap items-center gap-3'
+                style={{ animationDelay: '0.5s' }}
+              >
+                <Link
+                  href='/gallery/schicksal'
+                  className='group inline-flex items-center gap-2 rounded-full bg-kolping-400 px-6 py-3 text-sm font-bold text-white transition-all hover:bg-kolping-500 hover:shadow-[0_0_30px_rgba(255,122,0,0.3)]'
+                >
+                  Galerie ansehen
+                  <svg className='w-4 h-4 transition-transform group-hover:translate-x-0.5' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                    <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
+                  </svg>
+                </Link>
+                <Link
+                  href='/about'
+                  className='inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 backdrop-blur-sm px-6 py-3 text-sm font-medium text-white/90 transition-all hover:bg-white/10 hover:border-white/30'
+                >
+                  Über uns
+                </Link>
+              </div>
+            </div>
           </div>
         </div>
       </section>
 
-      <section className='mx-auto max-w-6xl'>
+      {/* === STATS RIBBON === */}
+      <section className='relative -mx-4 border-y border-site-700 bg-site-900'>
+        <div className='mx-auto max-w-6xl px-4 py-6 sm:py-8'>
+          <div className='grid grid-cols-3 gap-4 sm:gap-8 text-center'>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {yearsActive}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Jahre Bühne
+              </div>
+            </div>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {productionCount}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Produktionen
+              </div>
+            </div>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {teamData.current.length}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Ensemble
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* === THANK YOU BANNER === */}
+      <section className='relative -mx-4 bg-site-800/50'>
+        <div className='mx-auto max-w-6xl px-4 py-8 sm:py-10'>
+          <div className='flex flex-col sm:flex-row items-start sm:items-center gap-4 sm:gap-6'>
+            <div className='flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-kolping-400/10 border border-kolping-400/30 flex items-center justify-center'>
+              <svg className='w-5 h-5 sm:w-6 sm:h-6 text-kolping-400' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1.5} d='M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z' />
+              </svg>
+            </div>
+            <div>
+              <h3 className='font-display text-lg sm:text-xl font-bold tracking-tight'>
+                Vielen Dank!
+              </h3>
+              <p className='mt-1 text-sm sm:text-base text-site-100 max-w-2xl'>
+                Die Aufführungen sind vorüber. Wir bedanken uns herzlich bei allen Besuchern
+                für den großen Zuspruch und die tolle Stimmung! Bis zum nächsten Mal.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* === MARQUEE === */}
+      <section className='-mx-4 border-y border-site-700'>
         <Marquee items={marqueeItems} />
       </section>
 
-      <section className='mx-auto max-w-6xl space-y-4' aria-labelledby='productions-heading'>
-        <div className='flex items-center justify-between'>
-          <h2 id='productions-heading' className='font-display text-xl sm:text-2xl md:text-3xl font-extrabold tracking-tight'>
-            Produktionen
-          </h2>
+      {/* === PRODUCTIONS === Editorial grid */}
+      <section className='mx-auto max-w-6xl px-4 pt-16 sm:pt-20 pb-4' aria-labelledby='productions-heading'>
+        <div className='flex items-end justify-between mb-8 sm:mb-10'>
+          <div>
+            <span className='block text-[11px] sm:text-xs tracking-[0.2em] uppercase text-kolping-400 font-semibold mb-2'>
+              Unsere Stücke
+            </span>
+            <h2
+              id='productions-heading'
+              className='font-display text-3xl sm:text-4xl md:text-5xl font-black tracking-tight leading-none'
+            >
+              Produktionen
+            </h2>
+          </div>
           <Link
             href='/gallery'
-            className='text-sm text-site-200 hover:text-kolping-400 transition-colors flex items-center gap-1'
+            className='group hidden sm:inline-flex items-center gap-2 text-sm text-site-100 hover:text-kolping-400 transition-colors'
           >
-            Weitere
+            Alle ansehen
+            <svg className='w-4 h-4 transition-transform group-hover:translate-x-0.5' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
+            </svg>
+          </Link>
+        </div>
+
+        <FeaturedProductions items={featuredItems} />
+
+        <div className='mt-6 sm:hidden text-center'>
+          <Link
+            href='/gallery'
+            className='inline-flex items-center gap-2 text-sm text-site-100 hover:text-kolping-400 transition-colors'
+          >
+            Alle Produktionen ansehen
             <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
               <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
             </svg>
           </Link>
         </div>
-        <FeaturedProductions items={featuredItems} />
       </section>
 
-      <section className='mx-auto max-w-6xl' aria-labelledby='join-heading'>
-        <div className='glass rounded-xl p-5 sm:p-6 md:p-8 flex flex-col md:flex-row items-center gap-4 sm:gap-6'>
-          <div className='flex-1 text-center md:text-left'>
-            <h3 id='join-heading' className='font-display text-lg sm:text-xl md:text-2xl font-extrabold tracking-tight'>
-              Werde Teil der Bühne
-            </h3>
-            <p className='text-site-100 mt-1 text-sm sm:text-base'>
-              Ob Schauspiel, Technik oder Organisation – bei uns ist Platz für alle, die Theater lieben.
-            </p>
-          </div>
-          <div className='flex flex-wrap items-center gap-3'>
-            <a
-              href='https://www.instagram.com/kolpingjugend_ramsen/'
-              target='_blank'
-              rel='noopener noreferrer'
-              className='inline-flex items-center gap-2 px-4 py-2 rounded border border-site-700 hover:border-kolping-500 bg-site-800 transition-colors'
-              aria-label='Besuche uns auf Instagram'
-            >
-              Instagram
-            </a>
-            <Link
-              href='/about'
-              className='inline-flex items-center gap-2 px-4 py-2 rounded border border-site-700 hover:border-kolping-500 bg-site-800 transition-colors'
-            >
-              Über uns
-            </Link>
+      {/* === JOIN CTA === */}
+      <section className='mx-auto max-w-6xl px-4 py-16 sm:py-20' aria-labelledby='join-heading'>
+        <div className='relative overflow-hidden rounded-2xl border border-site-700'>
+          {/* Background atmospheric effect */}
+          <div className='absolute inset-0 bg-gradient-to-br from-kolping-400/5 via-site-900 to-site-900' />
+          <div className='absolute top-0 right-0 w-1/2 h-full bg-gradient-to-l from-kolping-400/[0.03] to-transparent' />
+
+          <div className='relative p-8 sm:p-10 md:p-14 flex flex-col md:flex-row items-center gap-8 md:gap-12'>
+            <div className='flex-1 text-center md:text-left'>
+              <span className='block text-[11px] sm:text-xs tracking-[0.2em] uppercase text-kolping-400 font-semibold mb-3'>
+                Mach mit
+              </span>
+              <h3
+                id='join-heading'
+                className='font-display text-2xl sm:text-3xl md:text-4xl font-black tracking-tight leading-tight'
+              >
+                Werde Teil
+                <br className='hidden sm:block' />
+                der Bühne
+              </h3>
+              <p className='text-site-100 mt-3 sm:mt-4 text-sm sm:text-base max-w-md leading-relaxed'>
+                Ob Schauspiel, Technik oder Organisation &ndash; bei uns ist
+                Platz für alle, die Theater lieben.
+              </p>
+            </div>
+            <div className='flex flex-col sm:flex-row items-center gap-3'>
+              <a
+                href='https://www.instagram.com/kolpingjugend_ramsen/'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='group inline-flex items-center gap-2.5 rounded-full bg-kolping-400 px-6 py-3 text-sm font-bold text-white transition-all hover:bg-kolping-500 hover:shadow-[0_0_30px_rgba(255,122,0,0.3)]'
+                aria-label='Besuche uns auf Instagram'
+              >
+                <svg className='w-4 h-4' viewBox='0 0 24 24' fill='currentColor'>
+                  <path d='M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7zm5 3.5a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11zm0 2a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7zM18 6.8a1 1 0 1 1-2 0 1 1 0 0 1 2 0z' />
+                </svg>
+                Instagram
+              </a>
+              <Link
+                href='/about'
+                className='inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/50 px-6 py-3 text-sm font-medium transition-all hover:border-kolping-400/50 hover:bg-site-800'
+              >
+                Über uns erfahren
+              </Link>
+            </div>
           </div>
         </div>
       </section>

--- a/src/components/FeaturedProductions.tsx
+++ b/src/components/FeaturedProductions.tsx
@@ -7,50 +7,120 @@ type Item = {
   tag?: string
   year?: number
   location?: string | null
+  dominantColor?: string
 }
 
 export default function FeaturedProductions({ items }: { items: Item[] }) {
+  const [hero, ...rest] = items
+
   return (
-    <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
-      {items.map((item, idx) => (
-        <a key={idx} href={item.href} className='group block tilt' aria-label={`Zur Galerie von ${item.title}`}>
-          <div className='poster-frame border border-site-700 bg-site-900 overflow-hidden'>
-            <div className='relative aspect-[4/5] w-full'>
-              <Image
-                src={item.image}
-                alt={item.title}
-                fill
-                sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
-                className='object-cover transition-transform duration-500 group-hover:scale-[1.04] w-full h-full'
-              />
-              <div className='absolute left-2 top-2 z-10 flex items-center gap-1.5'>
-                {item.tag ? (
-                  <span className='rounded bg-kolping-400 px-2 py-[2px] text-[11px] font-bold uppercase text-white'>
-                    {item.tag}
-                  </span>
-                ) : null}
-                {item.year ? (
-                  <span className='rounded bg-black/60 backdrop-blur-sm px-1.5 py-[2px] text-[10px] font-medium text-site-100'>
-                    {item.year}
-                  </span>
-                ) : null}
-                {item.location ? (
-                  <span className='rounded bg-black/60 backdrop-blur-sm px-1.5 py-[2px] text-[10px] font-medium text-site-100'>
-                    {item.location === 'Open-Air-Bühne' ? 'Open-Air' : 'Kreativ'}
-                  </span>
-                ) : null}
-              </div>
-              <div className='absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent transition-opacity duration-300 group-hover:from-black/90' />
-              <div className='absolute bottom-0 left-0 right-0 p-3'>
-                <h3 className='font-display text-lg font-extrabold tracking-tight text-site-50 transition-colors group-hover:text-kolping-400'>
-                  {item.title}
-                </h3>
-              </div>
+    <div className='space-y-4'>
+      {/* Hero card - featured production, larger */}
+      {hero && (
+        <a
+          href={hero.href}
+          className='group relative block overflow-hidden rounded-xl border border-site-700 tilt'
+          aria-label={`Zur Galerie von ${hero.title}`}
+        >
+          <div className='relative aspect-[21/9] sm:aspect-[2.4/1] w-full'>
+            <Image
+              src={hero.image}
+              alt={hero.title}
+              fill
+              sizes='(max-width: 1024px) 100vw, 1152px'
+              className='object-cover transition-transform duration-700 group-hover:scale-[1.03]'
+            />
+            {/* Color wash overlay from dominant color */}
+            <div
+              className='absolute inset-0 opacity-20 mix-blend-multiply transition-opacity duration-500 group-hover:opacity-10'
+              style={{ backgroundColor: hero.dominantColor }}
+            />
+            <div className='absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent' />
+            <div className='absolute inset-0 bg-gradient-to-r from-black/40 to-transparent' />
+
+            {/* Tags */}
+            <div className='absolute left-4 sm:left-6 top-4 sm:top-6 z-10 flex items-center gap-2'>
+              {hero.tag && (
+                <span className='rounded-full bg-kolping-400 px-3 py-1 text-[11px] font-bold uppercase tracking-wider text-white'>
+                  {hero.tag}
+                </span>
+              )}
+              {hero.year && (
+                <span className='rounded-full bg-black/50 backdrop-blur-sm px-2.5 py-1 text-[11px] font-medium text-white/80'>
+                  {hero.year}
+                </span>
+              )}
+              {hero.location && (
+                <span className='rounded-full bg-black/50 backdrop-blur-sm px-2.5 py-1 text-[11px] font-medium text-white/80'>
+                  {hero.location === 'Open-Air-Bühne' ? 'Open-Air' : 'Kreativ'}
+                </span>
+              )}
+            </div>
+
+            {/* Title */}
+            <div className='absolute bottom-0 left-0 right-0 p-4 sm:p-6'>
+              <h3 className='font-display text-2xl sm:text-3xl md:text-4xl font-black tracking-tight text-white transition-colors group-hover:text-kolping-400'>
+                {hero.title}
+              </h3>
             </div>
           </div>
         </a>
-      ))}
+      )}
+
+      {/* Grid - remaining productions */}
+      <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
+        {rest.map((item, idx) => (
+          <a
+            key={idx}
+            href={item.href}
+            className='group block tilt'
+            aria-label={`Zur Galerie von ${item.title}`}
+          >
+            <div className='relative overflow-hidden rounded-xl border border-site-700 bg-site-900'>
+              <div className='relative aspect-[4/5] w-full'>
+                <Image
+                  src={item.image}
+                  alt={item.title}
+                  fill
+                  sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
+                  className='object-cover transition-transform duration-500 group-hover:scale-[1.04]'
+                />
+                <div
+                  className='absolute inset-0 opacity-15 mix-blend-multiply transition-opacity duration-500 group-hover:opacity-5'
+                  style={{ backgroundColor: item.dominantColor }}
+                />
+                <div className='absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent transition-opacity duration-300 group-hover:from-black/90' />
+
+                {/* Tags */}
+                <div className='absolute left-3 top-3 z-10 flex items-center gap-1.5'>
+                  {item.tag && (
+                    <span className='rounded-full bg-kolping-400 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white'>
+                      {item.tag}
+                    </span>
+                  )}
+                  {item.year && (
+                    <span className='rounded-full bg-black/50 backdrop-blur-sm px-2 py-0.5 text-[10px] font-medium text-white/80'>
+                      {item.year}
+                    </span>
+                  )}
+                  {item.location && (
+                    <span className='rounded-full bg-black/50 backdrop-blur-sm px-2 py-0.5 text-[10px] font-medium text-white/80'>
+                      {item.location === 'Open-Air-Bühne' ? 'Open-Air' : 'Kreativ'}
+                    </span>
+                  )}
+                </div>
+
+                {/* Title */}
+                <div className='absolute bottom-0 left-0 right-0 p-3 sm:p-4'>
+                  <h3 className='font-display text-lg sm:text-xl font-extrabold tracking-tight text-white transition-colors group-hover:text-kolping-400'>
+                    {item.title}
+                  </h3>
+                </div>
+              </div>
+            </div>
+          </a>
+        ))}
+      </div>
     </div>
   )
 }
-

--- a/src/components/FeaturedProductions.tsx
+++ b/src/components/FeaturedProductions.tsx
@@ -15,60 +15,69 @@ export default function FeaturedProductions({ items }: { items: Item[] }) {
 
   return (
     <div className='space-y-4'>
-      {/* Hero card - featured production, larger */}
+      {/* Hero card - featured production with poster + info side-by-side on desktop */}
       {hero && (
         <a
           href={hero.href}
-          className='group relative block overflow-hidden rounded-xl border border-site-700 tilt'
+          className='group relative block overflow-hidden rounded-xl border border-site-700 bg-site-900 tilt'
           aria-label={`Zur Galerie von ${hero.title}`}
         >
-          <div className='relative aspect-[21/9] sm:aspect-[2.4/1] w-full'>
-            <Image
-              src={hero.image}
-              alt={hero.title}
-              fill
-              sizes='(max-width: 1024px) 100vw, 1152px'
-              className='object-cover transition-transform duration-700 group-hover:scale-[1.03]'
-            />
-            {/* Color wash overlay from dominant color */}
-            <div
-              className='absolute inset-0 opacity-20 mix-blend-multiply transition-opacity duration-500 group-hover:opacity-10'
-              style={{ backgroundColor: hero.dominantColor }}
-            />
-            <div className='absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent' />
-            <div className='absolute inset-0 bg-gradient-to-r from-black/40 to-transparent' />
-
-            {/* Tags */}
-            <div className='absolute left-4 sm:left-6 top-4 sm:top-6 z-10 flex items-center gap-2'>
-              {hero.tag && (
-                <span className='rounded-full bg-kolping-400 px-3 py-1 text-[11px] font-bold uppercase tracking-wider text-white'>
-                  {hero.tag}
-                </span>
-              )}
-              {hero.year && (
-                <span className='rounded-full bg-black/50 backdrop-blur-sm px-2.5 py-1 text-[11px] font-medium text-white/80'>
-                  {hero.year}
-                </span>
-              )}
-              {hero.location && (
-                <span className='rounded-full bg-black/50 backdrop-blur-sm px-2.5 py-1 text-[11px] font-medium text-white/80'>
-                  {hero.location === 'Open-Air-Bühne' ? 'Open-Air' : 'Kreativ'}
-                </span>
-              )}
+          <div className='flex flex-col sm:flex-row'>
+            {/* Poster image */}
+            <div className='relative w-full sm:w-2/5 lg:w-1/3 aspect-[3/4] sm:aspect-auto sm:min-h-[320px] md:min-h-[380px] flex-shrink-0'>
+              <Image
+                src={hero.image}
+                alt={hero.title}
+                fill
+                sizes='(max-width: 640px) 100vw, 400px'
+                className='object-cover object-top transition-transform duration-700 group-hover:scale-[1.03]'
+              />
+              <div
+                className='absolute inset-0 opacity-15 mix-blend-multiply transition-opacity duration-500 group-hover:opacity-5'
+                style={{ backgroundColor: hero.dominantColor }}
+              />
+              {/* Gradient fade into info area - bottom on mobile, right on desktop */}
+              <div className='absolute inset-0 bg-gradient-to-b sm:bg-gradient-to-r from-transparent via-transparent to-site-900/80 sm:to-site-900' />
             </div>
 
-            {/* Title */}
-            <div className='absolute bottom-0 left-0 right-0 p-4 sm:p-6'>
-              <h3 className='font-display text-2xl sm:text-3xl md:text-4xl font-black tracking-tight text-white transition-colors group-hover:text-kolping-400'>
+            {/* Info area */}
+            <div className='relative flex-1 flex flex-col justify-center p-5 sm:p-8 md:p-10 -mt-12 sm:mt-0'>
+              {/* Tags */}
+              <div className='flex items-center gap-2 mb-3 sm:mb-4'>
+                {hero.tag && (
+                  <span className='rounded-full bg-kolping-400 px-3 py-1 text-[11px] font-bold uppercase tracking-wider text-white'>
+                    {hero.tag}
+                  </span>
+                )}
+                {hero.year && (
+                  <span className='rounded-full bg-site-700/80 px-2.5 py-1 text-[11px] font-medium text-site-100'>
+                    {hero.year}
+                  </span>
+                )}
+                {hero.location && (
+                  <span className='rounded-full bg-site-700/80 px-2.5 py-1 text-[11px] font-medium text-site-100'>
+                    {hero.location === 'Open-Air-Bühne' ? 'Open-Air' : 'Kreativ'}
+                  </span>
+                )}
+              </div>
+
+              <h3 className='font-display text-2xl sm:text-3xl md:text-4xl font-black tracking-tight text-site-50 transition-colors group-hover:text-kolping-400'>
                 {hero.title}
               </h3>
+
+              <div className='mt-4 sm:mt-6 inline-flex items-center gap-2 text-sm text-site-100 group-hover:text-kolping-400 transition-colors'>
+                Galerie ansehen
+                <svg className='w-4 h-4 transition-transform group-hover:translate-x-1' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
+                </svg>
+              </div>
             </div>
           </div>
         </a>
       )}
 
-      {/* Grid - remaining productions */}
-      <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4'>
+      {/* Grid - remaining productions as poster cards */}
+      <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 sm:gap-4'>
         {rest.map((item, idx) => (
           <a
             key={idx}
@@ -77,44 +86,44 @@ export default function FeaturedProductions({ items }: { items: Item[] }) {
             aria-label={`Zur Galerie von ${item.title}`}
           >
             <div className='relative overflow-hidden rounded-xl border border-site-700 bg-site-900'>
-              <div className='relative aspect-[4/5] w-full'>
+              <div className='relative aspect-[3/4] w-full'>
                 <Image
                   src={item.image}
                   alt={item.title}
                   fill
-                  sizes='(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
-                  className='object-cover transition-transform duration-500 group-hover:scale-[1.04]'
+                  sizes='(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 20vw'
+                  className='object-cover object-top transition-transform duration-500 group-hover:scale-[1.04]'
                 />
                 <div
                   className='absolute inset-0 opacity-15 mix-blend-multiply transition-opacity duration-500 group-hover:opacity-5'
                   style={{ backgroundColor: item.dominantColor }}
                 />
-                <div className='absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent transition-opacity duration-300 group-hover:from-black/90' />
+                <div className='absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent transition-opacity duration-300' />
 
                 {/* Tags */}
-                <div className='absolute left-3 top-3 z-10 flex items-center gap-1.5'>
+                <div className='absolute left-2 top-2 z-10 flex flex-wrap items-center gap-1'>
                   {item.tag && (
-                    <span className='rounded-full bg-kolping-400 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white'>
+                    <span className='rounded-full bg-kolping-400 px-2 py-0.5 text-[9px] sm:text-[10px] font-bold uppercase tracking-wider text-white'>
                       {item.tag}
                     </span>
                   )}
                   {item.year && (
-                    <span className='rounded-full bg-black/50 backdrop-blur-sm px-2 py-0.5 text-[10px] font-medium text-white/80'>
+                    <span className='rounded-full bg-black/50 backdrop-blur-sm px-1.5 py-0.5 text-[9px] sm:text-[10px] font-medium text-white/80'>
                       {item.year}
-                    </span>
-                  )}
-                  {item.location && (
-                    <span className='rounded-full bg-black/50 backdrop-blur-sm px-2 py-0.5 text-[10px] font-medium text-white/80'>
-                      {item.location === 'Open-Air-Bühne' ? 'Open-Air' : 'Kreativ'}
                     </span>
                   )}
                 </div>
 
                 {/* Title */}
-                <div className='absolute bottom-0 left-0 right-0 p-3 sm:p-4'>
-                  <h3 className='font-display text-lg sm:text-xl font-extrabold tracking-tight text-white transition-colors group-hover:text-kolping-400'>
+                <div className='absolute bottom-0 left-0 right-0 p-2.5 sm:p-3'>
+                  <h3 className='font-display text-sm sm:text-base lg:text-lg font-extrabold tracking-tight text-white transition-colors group-hover:text-kolping-400 leading-tight'>
                     {item.title}
                   </h3>
+                  {item.location && (
+                    <span className='mt-1 block text-[10px] sm:text-[11px] text-white/60'>
+                      {item.location === 'Open-Air-Bühne' ? 'Open-Air' : 'Kreativbühne'}
+                    </span>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -5,19 +5,22 @@ type MarqueeProps = {
 export default function Marquee({ items }: MarqueeProps) {
   const doubled = [...items, ...items]
   return (
-    <div className='marquee border border-site-700 rounded-lg bg-site-800'>
-      <div className='marquee__track py-2 px-3 sm:px-4 text-[13px] sm:text-sm uppercase tracking-wide text-site-100'>
+    <div className='marquee bg-site-800/50'>
+      <div className='marquee__track py-3 px-4 text-[13px] sm:text-sm uppercase tracking-wider text-site-100'>
         {doubled.map((it, i) => (
-          <div key={i} className='flex items-center gap-2 whitespace-nowrap'>
+          <div key={i} className='flex items-center gap-2.5 whitespace-nowrap'>
             {it.marjor ? (
-              <span className='text-kolping-400'>◆</span>
-            ) : (<span className='opacity-80'>◆</span>)}
-              <span className='opacity-80'>{it.date}</span>
-            <span className='font-semibold'>{it.title}</span>
+              <span className='text-kolping-400 text-[10px]'>&#9670;</span>
+            ) : (
+              <span className='text-site-100/40 text-[10px]'>&#9670;</span>
+            )}
+            <span className='text-site-100/50 tabular-nums'>{it.date}</span>
+            <span className={it.marjor ? 'font-semibold text-site-50' : 'font-medium text-site-100/80'}>
+              {it.title}
+            </span>
           </div>
         ))}
       </div>
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary

- **Full-bleed cinematic hero**: Full-viewport image with Ken Burns animation, layered gradient overlays (directional + vignette), and staggered fade-in-up entrance animations
- **Bold editorial typography**: Title split across two lines with orange accent on the second word, massive responsive sizing (5xl to 9xl)
- **Stats ribbon**: Dynamic counters showing years active, production count, and ensemble size
- **Hero + grid production layout**: Featured latest production as a wide cinematic card, remaining 5 in a responsive 3-column poster grid with dominant color overlays from timeline data
- **Edge-to-edge sections**: Marquee, stats, and thank-you banner break out of the container for full-width dramatic effect
- **Refined details**: Pill-shaped buttons/tags, rounded badges, atmospheric gradient CTA section, improved responsive spacing

## Test plan

- [ ] Verify hero image loads and Ken Burns animation plays on desktop
- [ ] Check staggered entrance animations fire on page load
- [ ] Test responsive layout at mobile (390px), tablet (768px), and desktop (1440px)
- [ ] Verify light/dark theme toggle works across all new sections
- [ ] Confirm all links (gallery, about, Instagram) navigate correctly
- [ ] Test reduced-motion preference disables animations
- [ ] Check production cards render with correct images and metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)