### PR TITLE
Refactor and modernize About page design

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import timeline from '@/data/timeline.json'
+import teamData from '@/data/team.json'
 
 type TimelineEntry = {
   date: string
@@ -8,37 +9,42 @@ type TimelineEntry = {
   text: string
   image?: string
   galleryHash?: string
-  newYear?: boolean
   dominantColor?: string
+}
+
+type Play = {
+  location: string | null
+}
+
+type TeamData = {
+  current: { id: string }[]
+  plays: Play[]
 }
 
 export const dynamic = 'force-static'
 
-// Section Divider with theatrical curtain effect
 function SectionDivider({ title, subtitle }: { title: string; subtitle?: string }) {
   return (
     <div className='relative py-8 sm:py-12'>
       <div className='relative text-center space-y-3'>
         <div className='flex items-center justify-center gap-4'>
-          {/* Left decorative flourish */}
           <div className='hidden sm:flex items-center gap-2'>
             <div className='w-8 h-px bg-gradient-to-l from-kolping-500 to-transparent' />
             <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
             <div className='w-16 h-px bg-gradient-to-l from-kolping-500/80 to-transparent' />
           </div>
-          
+
           <h2 className='font-display text-2xl sm:text-3xl md:text-4xl font-extrabold tracking-tight text-kolping-400 drop-shadow-[0_0_20px_rgba(255,122,0,0.3)]'>
             {title}
           </h2>
-          
-          {/* Right decorative flourish */}
+
           <div className='hidden sm:flex items-center gap-2'>
             <div className='w-16 h-px bg-gradient-to-r from-kolping-500/80 to-transparent' />
             <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
             <div className='w-8 h-px bg-gradient-to-r from-kolping-500 to-transparent' />
           </div>
         </div>
-        
+
         {subtitle && (
           <p className='text-site-100 text-sm sm:text-base max-w-lg mx-auto'>
             {subtitle}
@@ -49,15 +55,12 @@ function SectionDivider({ title, subtitle }: { title: string; subtitle?: string 
   )
 }
 
-// Year separator with theatrical styling
 function YearSeparator({ year }: { year: string }) {
   return (
     <div className='relative py-6 sm:py-8 -ml-8 sm:-ml-10'>
       <div className='flex items-center gap-4'>
-        {/* Left spotlight beam */}
         <div className='flex-1 h-px bg-gradient-to-r from-transparent via-kolping-500/50 to-kolping-500/80' />
-        
-        {/* Year badge */}
+
         <div className='relative'>
           <div className='absolute -inset-3 bg-kolping-500/20 blur-xl rounded-full' />
           <div className='relative px-6 py-2 rounded-full bg-site-800 border border-kolping-500/40 backdrop-blur-sm'>
@@ -66,118 +69,113 @@ function YearSeparator({ year }: { year: string }) {
             </span>
           </div>
         </div>
-        
-        {/* Right spotlight beam */}
+
         <div className='flex-1 h-px bg-gradient-to-l from-transparent via-kolping-500/50 to-kolping-500/80' />
       </div>
     </div>
   )
 }
 
-// Production timeline card (with vertical banner image)
-function ProductionCard({ 
-  entry, 
-  index 
-}: { 
+function ProductionCard({
+  entry,
+  index,
+}: {
   entry: TimelineEntry
-  index: number 
+  index: number
 }) {
   const hasGallery = !!entry.galleryHash
-  
+
   const cardContent = (
-    <div 
+    <div
       className='group relative'
       style={{ animationDelay: `${index * 50}ms` }}
     >
-      {/* Card container */}
-      <div className='
-        relative poster-frame border-epic bg-site-800 
-        transition-all duration-500 ease-out
-        hover:scale-[1.02] hover:-translate-y-1
-        animate-fade-in-up
-      '>
-        {/* Theatrical spotlight glow on hover */}
+      <div className='relative poster-frame border-epic bg-site-800 transition-all duration-500 ease-out hover:scale-[1.02] hover:-translate-y-1 animate-fade-in-up'>
         <div className='absolute -inset-4 bg-gradient-to-b from-kolping-500/15 via-kolping-500/5 to-transparent rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl pointer-events-none' />
-        
+
         <div className='relative flex flex-col sm:flex-row overflow-hidden'>
-          {/* Image section - optimized for vertical banners */}
-          <div 
-            className='relative w-full sm:w-44 md:w-52 lg:w-60 aspect-[2/3] sm:aspect-auto sm:self-stretch overflow-hidden bg-site-900 shrink-0' 
+          <div
+            className='relative w-full sm:w-44 md:w-52 lg:w-60 aspect-[2/3] sm:aspect-auto sm:self-stretch overflow-hidden bg-site-900 shrink-0'
             style={{ backgroundColor: entry.dominantColor }}
           >
-            {/* Animated spotlight beam */}
             <div className='absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-700 pointer-events-none z-10'>
               <div className='absolute top-0 left-1/2 -translate-x-1/2 w-full h-full bg-gradient-to-b from-kolping-500/20 via-transparent to-transparent' />
             </div>
-            
+
             <Image
               src={`/img/${entry.image}`}
               alt={entry.header}
               fill
               className='object-contain transition-all duration-700 ease-out group-hover:scale-105 group-hover:brightness-110'
             />
-            
-            {/* Gradient overlays */}
+
             <div className='absolute inset-0 bg-gradient-to-r from-transparent via-transparent to-site-800/90 sm:block hidden z-10' />
             <div className='absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-site-800 via-site-800/60 to-transparent sm:hidden z-10' />
-            
-            {/* Year badge on mobile - positioned on the image */}
+
             <div className='absolute top-3 right-3 z-20 sm:hidden'>
               <div className='px-2.5 py-1 rounded-full bg-black/70 backdrop-blur-sm border border-kolping-500/40'>
-                <span className='text-[10px] font-bold uppercase tracking-wider text-kolping-400 font-mono'>{entry.date}</span>
+                <span className='text-[10px] font-bold uppercase tracking-wider text-kolping-400 font-mono'>
+                  {entry.date}
+                </span>
               </div>
             </div>
           </div>
-          
-          {/* Content section */}
+
           <div className='relative flex-1 p-5 sm:p-6 md:p-8 flex flex-col justify-center space-y-4'>
-            {/* Date badge - hidden on mobile, shown on sm+ */}
             <div className='hidden sm:flex items-center gap-3'>
               <div className='px-3 py-1 rounded-full bg-kolping-500/20 border border-kolping-500/30'>
-                <span className='text-xs font-bold uppercase tracking-wider text-kolping-400 font-mono'>{entry.date}</span>
+                <span className='text-xs font-bold uppercase tracking-wider text-kolping-400 font-mono'>
+                  {entry.date}
+                </span>
               </div>
               {hasGallery && (
                 <div className='px-2.5 py-1 rounded-full bg-site-700/50'>
-                  <span className='text-[10px] font-bold uppercase tracking-wider text-site-100'>Galerie</span>
+                  <span className='text-[10px] font-bold uppercase tracking-wider text-site-100'>
+                    Galerie
+                  </span>
                 </div>
               )}
             </div>
-            
+
             <div>
               <h3 className='font-display font-bold text-xl sm:text-2xl text-site-50 group-hover:text-kolping-400 transition-colors duration-300'>
                 {entry.header}
               </h3>
               <div className='w-12 h-0.5 bg-kolping-500 rounded-full mt-2 transition-all duration-500 group-hover:w-20' />
             </div>
-            
+
             <p className='text-sm sm:text-base text-site-100 leading-relaxed line-clamp-4 sm:line-clamp-3'>
               {entry.text}
             </p>
-            
+
             {hasGallery && (
               <div className='flex items-center gap-2 pt-2'>
                 <span className='text-sm font-semibold text-kolping-400 group-hover:text-kolping-500 transition-colors'>
                   Galerie ansehen
                 </span>
-                <svg 
-                  className='w-5 h-5 text-kolping-400 transition-transform duration-300 group-hover:translate-x-2' 
-                  fill='none' 
-                  viewBox='0 0 24 24' 
+                <svg
+                  className='w-5 h-5 text-kolping-400 transition-transform duration-300 group-hover:translate-x-2'
+                  fill='none'
+                  viewBox='0 0 24 24'
                   stroke='currentColor'
                 >
-                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M13 7l5 5m0 0l-5 5m5-5H6' />
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth={2}
+                    d='M13 7l5 5m0 0l-5 5m5-5H6'
+                  />
                 </svg>
               </div>
             )}
           </div>
         </div>
-        
-        {/* Bottom accent bar */}
+
         <div className='absolute bottom-0 inset-x-0 h-1 bg-gradient-to-r from-transparent via-kolping-500/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500' />
       </div>
     </div>
   )
-  
+
   if (hasGallery) {
     return (
       <Link href={`/gallery/${entry.galleryHash}`} className='block'>
@@ -185,32 +183,29 @@ function ProductionCard({
       </Link>
     )
   }
-  
+
   return cardContent
 }
 
-// Event timeline card (without image)
-function EventCard({ 
-  entry, 
-  index 
-}: { 
+function EventCard({
+  entry,
+  index,
+}: {
   entry: TimelineEntry
-  index: number 
+  index: number
 }) {
   return (
-    <div 
+    <div
       className='group relative animate-fade-in-up'
       style={{ animationDelay: `${index * 30}ms` }}
     >
-      {/* Timeline dot */}
       <div className='absolute -left-[39px] sm:-left-[47px] top-6 z-10'>
         <div className='relative'>
           <div className='absolute -inset-1 bg-kolping-500/40 rounded-full blur-sm opacity-0 group-hover:opacity-100 transition-opacity' />
           <div className='relative w-4 h-4 rounded-full bg-kolping-500 border-4 border-site-900 group-hover:scale-125 transition-transform' />
         </div>
       </div>
-      
-      {/* Content card */}
+
       <div className='glass rounded-xl p-5 sm:p-6 space-y-3 transition-all duration-300 hover:border-kolping-500/30 hover:bg-site-800/80'>
         <div className='flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4'>
           <div className='px-3 py-1 rounded-full bg-kolping-500/15 border border-kolping-500/25 w-fit'>
@@ -222,8 +217,8 @@ function EventCard({
             {entry.header}
           </h3>
         </div>
-        
-        <p className='text-sm sm:text-base text-site-100 leading-relaxed pl-0 sm:pl-0'>
+
+        <p className='text-sm sm:text-base text-site-100 leading-relaxed'>
           {entry.text}
         </p>
       </div>
@@ -232,122 +227,206 @@ function EventCard({
 }
 
 export default function AboutPage() {
-  const entries = (timeline as unknown as TimelineEntry[]).slice().reverse()
-  
-  return (
-    <div className='space-y-8 sm:space-y-12 md:space-y-16'>
-      {/* Epic Hero Section */}
-      <section className='relative -mt-8 pt-8 pb-8 sm:pb-12 overflow-hidden'>
-        {/* Background theatrical elements */}
-        <div className='absolute inset-0 pointer-events-none'>
-          {/* Stage spotlights */}
-          <div className='absolute top-0 left-1/4 w-96 h-96 bg-gradient-radial from-kolping-500/10 to-transparent blur-3xl' />
-          <div className='absolute top-0 right-1/4 w-96 h-96 bg-gradient-radial from-kolping-500/10 to-transparent blur-3xl' />
-        </div>
-        
-        <div className='relative text-center space-y-6'>
-          {/* Decorative top element */}
-          <div className='flex justify-center'>
-            <div className='relative'>
-              <div className='absolute -inset-4 bg-kolping-500/20 blur-2xl rounded-full' />
-              <svg className='relative w-12 h-12 text-kolping-500' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
-                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1} d='M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4' />
-              </svg>
-            </div>
-          </div>
-          
-          <h1 className='font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black tracking-tight'>
-            <span className='text-kolping-400 drop-shadow-[0_0_30px_rgba(255,122,0,0.4)]'>Unsere</span>{' '}
-            <span className='text-site-50'>Geschichte</span>
-          </h1>
-          
-          <p className='text-site-100 text-base sm:text-lg max-w-2xl mx-auto leading-relaxed'>
-            Von einer spontanen Idee zur festen Institution – 
-            <span className='text-kolping-400'> über 10 Jahre Theater</span> unter freiem Himmel 
-            in Ramsen.
-          </p>
-        </div>
-      </section>
+  const entries = (timeline as TimelineEntry[]).slice().reverse()
+  const theaterData = teamData as TeamData
+  const yearsActive = new Date().getFullYear() - 2014
+  const productionCount = theaterData.plays.length
+  const ensembleCount = theaterData.current.length
+  const stageFormats = new Set(
+    theaterData.plays
+      .map((play) => play.location)
+      .filter((location): location is string => !!location),
+  ).size
 
-      {/* Introduction Section */}
-      <section className='relative'>
-        <div className='glass rounded-xl p-6 sm:p-8 md:p-10 space-y-6 border-epic'>
-          <div className='flex items-start gap-4'>
-            <div className='hidden sm:block p-3 rounded-xl bg-kolping-500/10 border border-kolping-500/20'>
-              <svg className='w-8 h-8 text-kolping-500' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
-                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1.5} d='M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z' />
-              </svg>
-            </div>
-            <div className='prose prose-invert max-w-none prose-p:text-base sm:prose-p:text-lg prose-p:leading-relaxed'>
-              <p className='text-site-50 !mt-0'>
-                Wir sind das <strong className='text-kolping-400'>Kolping-Open-Air-Theater Ramsen</strong>. 
-                Seit 2014 entwickeln wir eigene Stücke und bringen sie jeden Sommer auf der Kolpingwiese zur Premiere. 
-                Der Eintritt ist frei – <em>Theater für alle</em>.
+  return (
+    <div className='space-y-0'>
+      <section className='relative -mx-4 -mt-8 overflow-hidden'>
+        <div className='relative w-full h-[75vh] min-h-[480px] max-h-[860px]'>
+          <Image
+            src='/img/other_images/Gruppenbild.jpg'
+            alt='Ensemble des Kolping-Open-Air-Theaters Ramsen'
+            fill
+            priority
+            sizes='100vw'
+            className='object-cover'
+          />
+          <div className='absolute inset-0 bg-gradient-to-b from-site-950/35 via-site-950/25 to-site-950' />
+          <div className='absolute inset-0 bg-gradient-to-r from-site-950/55 via-transparent to-site-950/35' />
+          <div className='vignette' />
+
+          <div className='absolute inset-0 flex flex-col justify-end pb-10 sm:pb-14 md:pb-16'>
+            <div className='mx-auto w-full max-w-6xl px-4'>
+              <div className='animate-fade-in-up mb-4 flex flex-wrap gap-2.5'>
+                <span className='inline-flex items-center rounded-full border border-kolping-400/40 bg-site-950/60 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.16em] text-kolping-400 uppercase'>
+                  Seit 2014
+                </span>
+                <span className='inline-flex items-center rounded-full border border-white/20 bg-site-950/55 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.14em] text-site-100 uppercase'>
+                  Open-Air & Kreativbühne
+                </span>
+                <span className='inline-flex items-center rounded-full border border-white/20 bg-site-950/55 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.14em] text-site-100 uppercase'>
+                  Eintritt frei
+                </span>
+              </div>
+
+              <h1 className='animate-fade-in-up font-display text-4xl sm:text-6xl md:text-7xl lg:text-8xl font-black tracking-tight leading-[0.92] text-shadow-lg'>
+                Über uns
+                <br />
+                <span className='text-kolping-400'>Kolpingtheater Ramsen</span>
+              </h1>
+
+              <p className='animate-fade-in-up mt-4 sm:mt-6 text-base sm:text-lg md:text-xl text-site-100/90 max-w-2xl leading-relaxed text-shadow'>
+                Wir schreiben unsere eigenen Geschichten und bringen sie als
+                Sommer- und Winterproduktionen auf die Bühne. Gemeinschaft,
+                Kreativität und Theater für alle stehen dabei im Mittelpunkt.
               </p>
             </div>
           </div>
-          
-          <div className='flex flex-wrap items-center gap-4 pt-2'>
-            <div className='flex items-center gap-3 text-sm sm:text-base text-site-100'>
-              <div className='p-2 rounded-lg bg-site-700/50'>
-                <svg 
-                  xmlns='http://www.w3.org/2000/svg' 
-                  viewBox='0 0 24 24' 
-                  fill='currentColor' 
-                  className='w-5 h-5 text-kolping-400'
-                >
-                  <path fillRule='evenodd' d='m11.54 22.351.07.04.028.016a.76.76 0 0 0 .723 0l.028-.015.071-.041a16.975 16.975 0 0 0 1.144-.742 19.58 19.58 0 0 0 2.683-2.282c1.944-1.99 3.963-4.98 3.963-8.827a8.25 8.25 0 0 0-16.5 0c0 3.846 2.02 6.837 3.963 8.827a19.58 19.58 0 0 0 2.682 2.282 16.975 16.975 0 0 0 1.145.742ZM12 13.5a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z' clipRule='evenodd' />
-                </svg>
+        </div>
+      </section>
+
+      <section className='relative -mx-4 border-y border-site-700 bg-site-900'>
+        <div className='mx-auto max-w-6xl px-4 py-6 sm:py-8'>
+          <div className='grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-8 text-center'>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {yearsActive}
               </div>
-              <span>Klosterhof 7, 67305 Ramsen</span>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Jahre Bühne
+              </div>
             </div>
-            
-            <div className='flex items-center gap-3 text-sm sm:text-base text-site-100'>
-              <div className='p-2 rounded-lg bg-site-700/50'>
-                <svg 
-                  xmlns='http://www.w3.org/2000/svg' 
-                  viewBox='0 0 24 24' 
-                  fill='currentColor' 
-                  className='w-5 h-5 text-kolping-400'
-                >
-                  <path d='M12.75 12.75a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM7.5 15.75a.75.75 0 100-1.5.75.75 0 000 1.5zM8.25 17.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM9.75 15.75a.75.75 0 100-1.5.75.75 0 000 1.5zM10.5 17.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM12 15.75a.75.75 0 100-1.5.75.75 0 000 1.5zM12.75 17.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM14.25 15.75a.75.75 0 100-1.5.75.75 0 000 1.5zM15 17.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM16.5 15.75a.75.75 0 100-1.5.75.75 0 000 1.5zM15 12.75a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM16.5 13.5a.75.75 0 100-1.5.75.75 0 000 1.5z' />
-                  <path fillRule='evenodd' d='M6.75 2.25A.75.75 0 017.5 3v1.5h9V3A.75.75 0 0118 3v1.5h.75a3 3 0 013 3v11.25a3 3 0 01-3 3H5.25a3 3 0 01-3-3V7.5a3 3 0 013-3H6V3a.75.75 0 01.75-.75zm13.5 9a1.5 1.5 0 00-1.5-1.5H5.25a1.5 1.5 0 00-1.5 1.5v7.5a1.5 1.5 0 001.5 1.5h13.5a1.5 1.5 0 001.5-1.5v-7.5z' clipRule='evenodd' />
-                </svg>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {productionCount}
               </div>
-              <span>Jeden Sommer Open-Air</span>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Produktionen
+              </div>
+            </div>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {ensembleCount}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Ensemble
+              </div>
+            </div>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {stageFormats}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Bühnenformate
+              </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Timeline Section */}
-      <section className='space-y-4' aria-labelledby='timeline-heading'>
-        <SectionDivider 
-          title="Chronik" 
-          subtitle="Eine Reise durch unsere Theatergeschichte"
+      <section className='mx-auto max-w-6xl px-4 py-12 sm:py-16 space-y-6 sm:space-y-8'>
+        <SectionDivider
+          title='Wer wir sind'
+          subtitle='Theatergruppe, Team und Treffpunkt in Ramsen'
         />
-        
+
+        <div className='grid lg:grid-cols-[1.2fr_1fr] gap-6 sm:gap-8'>
+          <div className='glass border-epic rounded-xl p-6 sm:p-8 space-y-5'>
+            <p className='text-site-50 text-base sm:text-lg leading-relaxed'>
+              Das Kolping-Open-Air-Theater Ramsen entwickelt seit 2014 eigene
+              Stücke und bringt sie jährlich zur Premiere. Unser großes
+              Sommerstück auf der Kolpingwiese und die Kreativbühne im Winter
+              verbinden historische Stoffe, Fantasie und aktuelle Themen.
+            </p>
+            <p className='text-site-100 text-sm sm:text-base leading-relaxed'>
+              Ob auf der Bühne, in der Technik, beim Bau, in Kostüm oder
+              Organisation: Wir arbeiten als Gemeinschaft und schaffen Theater,
+              das für alle offen ist.
+            </p>
+            <div className='pt-2 flex flex-wrap gap-3'>
+              <Link
+                href='/team'
+                className='inline-flex items-center gap-2 rounded-full bg-kolping-400 px-5 py-2.5 text-sm font-bold text-white transition-all hover:bg-kolping-500 hover:shadow-[0_0_24px_rgba(255,122,0,0.25)]'
+              >
+                Unser Team
+              </Link>
+              <Link
+                href='/contact'
+                className='inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/70 px-5 py-2.5 text-sm font-medium transition-all hover:border-kolping-400/60 hover:bg-site-800'
+              >
+                Kontakt aufnehmen
+              </Link>
+            </div>
+          </div>
+
+          <div className='glass rounded-xl p-6 sm:p-8 space-y-5'>
+            <h3 className='font-display text-2xl font-bold tracking-tight'>
+              Treffpunkt & Proben
+            </h3>
+            <div className='space-y-4 text-sm sm:text-base'>
+              <div className='rounded-lg bg-site-800/60 border border-site-700 p-4'>
+                <div className='text-[11px] tracking-[0.18em] uppercase text-kolping-400 font-semibold mb-1'>
+                  Ort
+                </div>
+                <p className='text-site-50'>Klosterhof 7, 67305 Ramsen</p>
+              </div>
+              <div className='rounded-lg bg-site-800/60 border border-site-700 p-4'>
+                <div className='text-[11px] tracking-[0.18em] uppercase text-kolping-400 font-semibold mb-1'>
+                  Regelmäßige Probe
+                </div>
+                <p className='text-site-50'>Jeden Mittwoch, 19:00 Uhr</p>
+              </div>
+              <div className='rounded-lg bg-site-800/60 border border-site-700 p-4'>
+                <div className='text-[11px] tracking-[0.18em] uppercase text-kolping-400 font-semibold mb-1'>
+                  Mitmachen
+                </div>
+                <p className='text-site-100'>
+                  Schauspiel, Technik oder Organisation: neue Gesichter sind
+                  immer willkommen.
+                </p>
+              </div>
+            </div>
+            <a
+              href='https://www.instagram.com/kolpingjugend_ramsen/'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='inline-flex items-center gap-2 text-sm text-kolping-400 hover:text-kolping-500 transition-colors'
+            >
+              Instagram ansehen
+              <svg className='w-4 h-4' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
+              </svg>
+            </a>
+          </div>
+        </div>
+      </section>
+
+      <section className='mx-auto max-w-6xl px-4 pb-8 sm:pb-12 space-y-4' aria-labelledby='timeline-heading'>
+        <SectionDivider
+          title='Chronik'
+          subtitle='Eine Reise durch unsere Theatergeschichte'
+        />
+
+        <h2 id='timeline-heading' className='sr-only'>
+          Chronik
+        </h2>
+
         <div className='relative pl-8 sm:pl-10'>
-          {/* Timeline line */}
           <div className='absolute left-0 top-0 bottom-0 w-px bg-gradient-to-b from-kolping-500/80 via-site-700 to-site-700' />
-          
+
           <div className='space-y-6 sm:space-y-8'>
-            {entries.map((entry, i) => {
+            {entries.map((entry, index) => {
               const currentYear = entry.date.split(' ')[1]
-              const previousYear = i > 0 ? entries[i - 1].date.split(' ')[1] : null
+              const previousYear = index > 0 ? entries[index - 1].date.split(' ')[1] : null
               const isNewYear = currentYear !== previousYear
               const isProduction = !!entry.image
 
               return (
-                <div key={i}>
-                  {isNewYear && (
-                    <YearSeparator year={currentYear} />
-                  )}
-                  
+                <div key={`${entry.date}-${entry.header}`}>
+                  {isNewYear && <YearSeparator year={currentYear} />}
                   {isProduction ? (
-                    <ProductionCard entry={entry} index={i} />
+                    <ProductionCard entry={entry} index={index} />
                   ) : (
-                    <EventCard entry={entry} index={i} />
+                    <EventCard entry={entry} index={index} />
                   )}
                 </div>
               )
@@ -356,33 +435,44 @@ export default function AboutPage() {
         </div>
       </section>
 
-      {/* Stats Section */}
-      <section className='relative'>
-        <div className='absolute inset-0 pointer-events-none'>
-          <div className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-radial from-kolping-500/5 to-transparent blur-3xl' />
-        </div>
-        
-        <div className='relative grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6'>
-          {[
-            { value: '10+', label: 'Jahre Theater', icon: '🎭' },
-            { value: '15+', label: 'Produktionen', icon: '📽️' },
-            { value: '1000+', label: 'Zuschauer/Jahr', icon: '👥' },
-            { value: '1', label: 'Jugendpreis', icon: '🏆' },
-          ].map((stat, i) => (
-            <div 
-              key={i}
-              className='glass rounded-xl p-5 sm:p-6 text-center space-y-2 hover:border-kolping-500/30 transition-colors animate-fade-in-up'
-              style={{ animationDelay: `${i * 100}ms` }}
-            >
-              <div className='text-2xl sm:text-3xl'>{stat.icon}</div>
-              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
-                {stat.value}
-              </div>
-              <div className='text-xs sm:text-sm text-site-100 font-medium'>
-                {stat.label}
-              </div>
+      <section className='mx-auto max-w-6xl px-4 py-12 sm:py-16'>
+        <div className='relative overflow-hidden rounded-2xl border border-site-700'>
+          <div className='absolute inset-0 bg-gradient-to-br from-kolping-400/10 via-site-900 to-site-900' />
+          <div className='absolute top-0 right-0 w-1/2 h-full bg-gradient-to-l from-kolping-400/[0.05] to-transparent' />
+
+          <div className='relative p-8 sm:p-10 md:p-14 flex flex-col md:flex-row items-center gap-8 md:gap-12'>
+            <div className='flex-1 text-center md:text-left'>
+              <span className='block text-[11px] sm:text-xs tracking-[0.2em] uppercase text-kolping-400 font-semibold mb-3'>
+                Mitmachen
+              </span>
+              <h2 className='font-display text-2xl sm:text-3xl md:text-4xl font-black tracking-tight leading-tight'>
+                Werde Teil
+                <br className='hidden sm:block' />
+                der Theatergruppe
+              </h2>
+              <p className='text-site-100 mt-3 sm:mt-4 text-sm sm:text-base max-w-md leading-relaxed'>
+                Wenn du Lust auf Schauspiel, Technik oder kreative Arbeit hast,
+                melde dich bei uns. Wir freuen uns auf neue Ideen.
+              </p>
             </div>
-          ))}
+            <div className='flex flex-col sm:flex-row items-center gap-3'>
+              <Link
+                href='/contact'
+                className='group inline-flex items-center gap-2.5 rounded-full bg-kolping-400 px-6 py-3 text-sm font-bold text-white transition-all hover:bg-kolping-500 hover:shadow-[0_0_30px_rgba(255,122,0,0.3)]'
+              >
+                Kontakt
+                <svg className='w-4 h-4 transition-transform group-hover:translate-x-0.5' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
+                </svg>
+              </Link>
+              <Link
+                href='/team'
+                className='inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/50 px-6 py-3 text-sm font-medium transition-all hover:border-kolping-400/50 hover:bg-site-800'
+              >
+                Team ansehen
+              </Link>
+            </div>
+          </div>
         </div>
       </section>
     </div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -84,15 +84,6 @@ function ProductionCard({
     >
       <div className='relative poster-frame border-epic bg-site-800 transition-all duration-500 ease-out hover:scale-[1.02] hover:-translate-y-1 animate-fade-in-up'>
         <div className='absolute -inset-4 bg-gradient-to-b from-kolping-500/15 via-kolping-500/5 to-transparent rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl pointer-events-none' />
-        <div className='absolute top-3 left-3 z-30 hidden sm:flex items-center gap-2 rounded-full border border-site-700 bg-site-900/80 backdrop-blur-sm px-3 py-1'>
-          <span className='text-[10px] font-bold tracking-[0.18em] text-kolping-400 uppercase'>
-            #{entry.order}
-          </span>
-          <span className='text-[10px] tracking-[0.12em] text-site-100 uppercase'>
-            Produktion
-          </span>
-        </div>
-
         <div className='relative flex flex-col sm:flex-row overflow-hidden'>
           <div
             className='relative w-full sm:w-44 md:w-52 lg:w-60 aspect-[2/3] sm:aspect-auto sm:self-stretch overflow-hidden bg-site-900 shrink-0'

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -140,7 +140,7 @@ function ProductionCard({
 
             <div className='absolute top-3 right-3 z-20 sm:hidden'>
               <div className='px-2.5 py-1 rounded-full bg-black/70 backdrop-blur-sm border border-kolping-500/40'>
-                <span className='text-[10px] font-bold uppercase tracking-wider text-kolping-400 font-mono'>
+                <span className='text-[10px] font-bold uppercase tracking-wider text-kolping-400 font-mono whitespace-nowrap'>
                   {entry.month} {entry.year}
                 </span>
               </div>
@@ -150,7 +150,7 @@ function ProductionCard({
           <div className='relative flex-1 p-5 sm:p-6 md:p-8 flex flex-col justify-center space-y-4'>
             <div className='hidden sm:flex items-center gap-3'>
               <div className='px-3 py-1 rounded-full bg-kolping-500/20 border border-kolping-500/30'>
-                <span className='text-xs font-bold uppercase tracking-wider text-kolping-400 font-mono'>
+                <span className='text-xs font-bold uppercase tracking-wider text-kolping-400 font-mono whitespace-nowrap'>
                   {entry.month} {entry.year}
                 </span>
               </div>
@@ -237,7 +237,7 @@ function EventCard({
       <div className='glass rounded-xl p-5 sm:p-6 space-y-3 transition-all duration-300 hover:border-kolping-500/30 hover:bg-site-800/80'>
         <div className='flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4'>
           <div className='px-3 py-1 rounded-full bg-kolping-500/15 border border-kolping-500/25 w-fit'>
-            <time className='text-xs font-bold text-kolping-400 uppercase tracking-wider font-mono'>
+            <time className='text-xs font-bold text-kolping-400 uppercase tracking-wider font-mono whitespace-nowrap'>
               {entry.month} {entry.year}
             </time>
           </div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -346,7 +346,7 @@ export default function AboutPage() {
         />
 
         <div className='grid lg:grid-cols-[1.2fr_1fr] gap-6 sm:gap-8'>
-          <div className='glass border-epic rounded-xl p-6 sm:p-8 space-y-5'>
+          <div className='glass border-epic relative isolate rounded-xl p-6 sm:p-8 space-y-5'>
             <p className='text-site-50 text-base sm:text-lg leading-relaxed'>
               Das Kolping-Open-Air-Theater Ramsen entwickelt seit 2014 eigene
               Stücke und bringt sie jährlich zur Premiere. Unser großes
@@ -358,16 +358,16 @@ export default function AboutPage() {
               Organisation: Wir arbeiten als Gemeinschaft und schaffen Theater,
               das für alle offen ist.
             </p>
-            <div className='pt-2 flex flex-wrap gap-3'>
+            <div className='relative z-20 pt-2 flex flex-wrap gap-3'>
               <Link
                 href='/team'
-                className='inline-flex items-center gap-2 rounded-full bg-kolping-400 px-5 py-2.5 text-sm font-bold text-white transition-all hover:bg-kolping-500 hover:shadow-[0_0_24px_rgba(255,122,0,0.25)]'
+                className='relative z-20 inline-flex items-center gap-2 rounded-full bg-kolping-400 px-5 py-2.5 text-sm font-bold text-white transition-all hover:bg-kolping-500 hover:shadow-[0_0_24px_rgba(255,122,0,0.25)]'
               >
                 Unser Team
               </Link>
               <Link
                 href='/contact'
-                className='inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/70 px-5 py-2.5 text-sm font-medium transition-all hover:border-kolping-400/60 hover:bg-site-800'
+                className='relative z-20 inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/70 px-5 py-2.5 text-sm font-medium transition-all hover:border-kolping-400/60 hover:bg-site-800'
               >
                 Kontakt aufnehmen
               </Link>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -18,11 +18,6 @@ type TimelineItem = TimelineEntry & {
   order: number
 }
 
-type TimelineYearGroup = {
-  year: string
-  entries: TimelineItem[]
-}
-
 type Play = {
   location: string | null
 }
@@ -68,27 +63,6 @@ function SectionDivider({ title, subtitle }: { title: string; subtitle?: string 
             {subtitle}
           </p>
         )}
-      </div>
-    </div>
-  )
-}
-
-function YearSeparator({ year }: { year: string }) {
-  return (
-    <div className='relative py-6 sm:py-8 -ml-8 sm:-ml-10'>
-      <div className='flex items-center gap-4'>
-        <div className='flex-1 h-px bg-gradient-to-r from-transparent via-kolping-500/50 to-kolping-500/80' />
-
-        <div className='relative'>
-          <div className='absolute -inset-3 bg-kolping-500/20 blur-xl rounded-full' />
-          <div className='relative px-6 py-2 rounded-full bg-site-800 border border-kolping-500/40 backdrop-blur-sm'>
-            <span className='font-display text-2xl sm:text-3xl font-black text-kolping-400 tracking-tight drop-shadow-[0_0_10px_rgba(255,122,0,0.4)]'>
-              {year}
-            </span>
-          </div>
-        </div>
-
-        <div className='flex-1 h-px bg-gradient-to-l from-transparent via-kolping-500/50 to-kolping-500/80' />
       </div>
     </div>
   )
@@ -268,15 +242,6 @@ export default function AboutPage() {
       order: index + 1,
     }
   })
-  const timelineGroups = entries.reduce<TimelineYearGroup[]>((groups, entry) => {
-    const lastGroup = groups[groups.length - 1]
-    if (!lastGroup || lastGroup.year !== entry.year) {
-      groups.push({ year: entry.year, entries: [entry] })
-      return groups
-    }
-    lastGroup.entries.push(entry)
-    return groups
-  }, [])
   const productionsInTimeline = entries.filter((entry) => !!entry.image).length
   const eventsInTimeline = entries.length - productionsInTimeline
   const theaterData = teamData as TeamData
@@ -491,73 +456,25 @@ export default function AboutPage() {
           </div>
         </div>
 
-        <div className='sticky top-[72px] z-20 -mx-1 px-1 py-3 backdrop-blur supports-[backdrop-filter]:bg-site-900/55 bg-site-900/75 rounded-xl border border-site-700/60'>
-          <div className='flex items-center gap-2 overflow-x-auto scrollbar-thin pb-1'>
-            {timelineGroups.map((group) => (
-              <a
-                key={group.year}
-                href={`#timeline-year-${group.year}`}
-                className='shrink-0 inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/80 px-3 py-1.5 text-xs text-site-100 hover:border-kolping-400/60 hover:text-kolping-400 transition-colors'
-              >
-                <span className='font-semibold'>{group.year}</span>
-                <span className='inline-flex min-w-5 h-5 items-center justify-center rounded-full bg-site-700 text-[10px] text-site-100'>
-                  {group.entries.length}
-                </span>
-              </a>
-            ))}
+        <div className='relative pl-8 sm:pl-10'>
+          <div className='absolute left-0 top-0 bottom-0 w-px bg-gradient-to-b from-kolping-500/80 via-site-700 to-site-700' />
+          <div className='grid gap-5 sm:gap-6 md:grid-cols-2'>
+            {entries.map((entry, index) => {
+              const isProduction = !!entry.image
+              return (
+                <div
+                  key={`${entry.date}-${entry.header}`}
+                  className={isProduction ? 'md:col-span-2' : ''}
+                >
+                  {isProduction ? (
+                    <ProductionCard entry={entry} index={index} />
+                  ) : (
+                    <EventCard entry={entry} index={index} />
+                  )}
+                </div>
+              )
+            })}
           </div>
-        </div>
-
-        <div className='space-y-10 sm:space-y-14 pt-2'>
-          {timelineGroups.map((group, groupIndex) => {
-            const productionCountForYear = group.entries.filter((entry) => !!entry.image).length
-            const eventCountForYear = group.entries.length - productionCountForYear
-
-            return (
-              <section
-                key={group.year}
-                id={`timeline-year-${group.year}`}
-                className='scroll-mt-32 space-y-4'
-                aria-label={`Einträge aus dem Jahr ${group.year}`}
-              >
-                <YearSeparator year={group.year} />
-                <div className='-mt-3 sm:-mt-2 flex flex-wrap gap-2 sm:gap-3'>
-                  <span className='inline-flex items-center rounded-full border border-site-700 bg-site-800/70 px-3 py-1 text-xs text-site-100'>
-                    {group.entries.length} Einträge
-                  </span>
-                  <span className='inline-flex items-center rounded-full border border-site-700 bg-site-800/70 px-3 py-1 text-xs text-site-100'>
-                    {productionCountForYear} Produktionen
-                  </span>
-                  <span className='inline-flex items-center rounded-full border border-site-700 bg-site-800/70 px-3 py-1 text-xs text-site-100'>
-                    {eventCountForYear} Ereignisse
-                  </span>
-                </div>
-
-                <div className='relative pl-8 sm:pl-10'>
-                  <div className='absolute left-0 top-0 bottom-0 w-px bg-gradient-to-b from-kolping-500/80 via-site-700 to-site-700' />
-                  <div className='grid gap-5 sm:gap-6 md:grid-cols-2'>
-                    {group.entries.map((entry, index) => {
-                      const isProduction = !!entry.image
-                      const animationIndex = groupIndex * 6 + index
-
-                      return (
-                        <div
-                          key={`${entry.date}-${entry.header}`}
-                          className={isProduction ? 'md:col-span-2' : ''}
-                        >
-                          {isProduction ? (
-                            <ProductionCard entry={entry} index={animationIndex} />
-                          ) : (
-                            <EventCard entry={entry} index={animationIndex} />
-                          )}
-                        </div>
-                      )
-                    })}
-                  </div>
-                </div>
-              </section>
-            )
-          })}
         </div>
       </section>
 

--- a/src/app/gallery/[play]/Lightbox.tsx
+++ b/src/app/gallery/[play]/Lightbox.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { useEffect, useState, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import { decodeHtmlEntities } from '@/lib/html'
 
 type SlideDirection = 'left' | 'right' | null
@@ -30,11 +31,13 @@ export function Lightbox({
   const [isClosing, setIsClosing] = useState(false)
   const [slideDirection, setSlideDirection] = useState<SlideDirection>(null)
   const [imageKey, setImageKey] = useState(src)
+  const [mounted, setMounted] = useState(false)
   const decodedAlt = decodeHtmlEntities(alt)
   const decodedCaption = caption ? decodeHtmlEntities(caption) : undefined
 
   // Trigger entrance animation
   useEffect(() => {
+    setMounted(true)
     requestAnimationFrame(() => {
       setIsVisible(true)
     })
@@ -98,7 +101,9 @@ export function Lightbox({
     return 'animate-scale-fade-in'
   }
 
-  return (
+  if (!mounted) return null
+
+  const content = (
     <div
       className={`
         fixed inset-0 z-50 flex items-center justify-center p-4
@@ -359,4 +364,6 @@ export function Lightbox({
       `}</style>
     </div>
   )
+
+  return createPortal(content, document.body)
 }

--- a/src/app/gallery/[play]/page.tsx
+++ b/src/app/gallery/[play]/page.tsx
@@ -1,11 +1,12 @@
 export const runtime = 'edge'
+import Link from 'next/link'
+import Image from 'next/image'
+import { notFound } from 'next/navigation'
 import ClientGrid from './ClientGrid'
 import pics from '@/data/pics.json'
 import imagesMeta from '@/data/images.json'
 import timeline from '@/data/timeline.json'
 import team from '@/data/team.json'
-import { notFound } from 'next/navigation'
-import Link from 'next/link'
 
 type PhotoMeta = { width: number; height: number; alt: string; index: number }
 
@@ -17,7 +18,54 @@ type Play = {
   gallery: boolean
 }
 
-const plays: Play[] = (team as unknown as { plays: Play[] }).plays
+type TimelineEntry = {
+  galleryHash?: string
+  header?: string
+  date?: string
+  image?: string
+  dominantColor?: string
+}
+
+const plays: Play[] = (team as { plays: Play[] }).plays
+
+function parseDateParts(date: string) {
+  const parts = date.trim().split(' ').filter(Boolean)
+  const year = parts[parts.length - 1] ?? date
+  const month = parts.slice(0, -1).join(' ') || date
+  return { month, year }
+}
+
+function SectionDivider({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className='relative py-8 sm:py-12'>
+      <div className='relative text-center space-y-3'>
+        <div className='flex items-center justify-center gap-4'>
+          <div className='hidden sm:flex items-center gap-2'>
+            <div className='w-8 h-px bg-gradient-to-l from-kolping-500 to-transparent' />
+            <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
+            <div className='w-16 h-px bg-gradient-to-l from-kolping-500/80 to-transparent' />
+          </div>
+
+          <h2 className='font-display text-2xl sm:text-3xl md:text-4xl font-extrabold tracking-tight text-kolping-400 drop-shadow-[0_0_20px_rgba(255,122,0,0.3)]'>
+            {title}
+          </h2>
+
+          <div className='hidden sm:flex items-center gap-2'>
+            <div className='w-16 h-px bg-gradient-to-r from-kolping-500/80 to-transparent' />
+            <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
+            <div className='w-8 h-px bg-gradient-to-r from-kolping-500 to-transparent' />
+          </div>
+        </div>
+
+        {subtitle && (
+          <p className='text-site-100 text-sm sm:text-base max-w-xl mx-auto'>
+            {subtitle}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
 
 export default async function PlayGalleryPage({
   params,
@@ -26,156 +74,166 @@ export default async function PlayGalleryPage({
 }) {
   const { play } = await params
   const key = play as keyof typeof pics
-  const captions = (pics as unknown as Record<string, string[]>)[key] as
-    | string[]
-    | undefined
-  const metas = (imagesMeta as unknown as Record<string, PhotoMeta[]>)[key] as
-    | PhotoMeta[]
-    | undefined
-  
-  const hasImages = !!(captions && metas && metas.length > 0)
+  const captions = (pics as Record<string, string[]>)[key]
+  const metas = (imagesMeta as Record<string, PhotoMeta[]>)[key]
+  const hasImages = Boolean(captions && metas && metas.length > 0)
 
-  // Try to find in timeline (for title/date)
-  const timelineEntry = (
-    timeline as unknown as { galleryHash?: string; header?: string; date?: string }[]
-  ).find((t) => t.galleryHash === play)
-  
-  // Try to find in team.json (for validation and fallback title)
-  const playData = plays.find(p => p.slug === play)
-  const isValidPlay = !!playData || !!timelineEntry
-  
-  if (!isValidPlay) return notFound()
-    
-  const title = timelineEntry?.header || playData?.play || play
-  const date = timelineEntry?.date || playData?.year.toString()
-
-  // Common Hero Section
-  const renderHero = (subtitle: React.ReactNode) => (
-    <section className='relative -mt-8 pt-8 pb-12 sm:pb-16 overflow-hidden'>
-      {/* Background theatrical elements */}
-      <div className='absolute inset-0 pointer-events-none'>
-        {/* Stage spotlights */}
-        <div className='absolute top-0 left-1/4 w-96 h-96 bg-gradient-radial from-kolping-500/10 to-transparent blur-3xl' />
-        <div className='absolute top-0 right-1/4 w-96 h-96 bg-gradient-radial from-kolping-500/10 to-transparent blur-3xl' />
-      </div>
-      
-      <div className='relative text-center space-y-6'>
-        {/* Back link */}
-        <Link 
-          href='/gallery' 
-          className='inline-flex items-center gap-2 text-site-300 hover:text-kolping-400 transition-colors duration-300 group'
-        >
-          <svg 
-            className='w-4 h-4 transition-transform duration-300 group-hover:-translate-x-1' 
-            fill='none' 
-            viewBox='0 0 24 24' 
-            stroke='currentColor'
-          >
-            <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M11 17l-5-5m0 0l5-5m-5 5h12' />
-          </svg>
-          <span className='text-sm font-medium'>Zurück zur Galerie</span>
-        </Link>
-        
-        {/* Decorative top element */}
-        <div className='flex justify-center'>
-          <div className='relative'>
-            <div className='absolute -inset-4 bg-kolping-500/20 blur-2xl rounded-full' />
-            <svg className='relative w-12 h-12 text-kolping-500' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
-              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1} d='M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' />
-            </svg>
-          </div>
-        </div>
-        
-        <div className='space-y-2'>
-          <h1 
-            className='font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black tracking-tight text-kolping-400 drop-shadow-[0_0_30px_rgba(255,122,0,0.4)]'
-            style={{ viewTransitionName: `gallery-title-${play}` }}
-          >
-            {title}
-          </h1>
-          
-          {date && (
-            <div className='flex justify-center'>
-              <div className='px-3 py-1 rounded-full bg-site-800/50 border border-kolping-500/30'>
-                <span className='text-sm font-mono text-kolping-400'>{date}</span>
-              </div>
-            </div>
-          )}
-        </div>
-        
-        <p className='text-site-100 text-base sm:text-lg max-w-2xl mx-auto leading-relaxed'>
-          {subtitle}
-        </p>
-      </div>
-    </section>
+  const timelineEntry = (timeline as TimelineEntry[]).find(
+    (entry) => entry.galleryHash === play,
   )
+  const playData = plays.find((entry) => entry.slug === play)
+  const isValidPlay = Boolean(playData || timelineEntry)
+  if (!isValidPlay) return notFound()
 
-  if (!hasImages) {
-    return (
-      <div className='space-y-8 sm:space-y-12 md:space-y-16'>
-        {renderHero(
-          <>
-            Hier entsteht die Galerie für <span className='text-kolping-400'>{title}</span>.
-          </>
-        )}
-        
-        <div className='flex flex-col items-center justify-center py-20 px-4 text-center space-y-6'>
-          <div className='w-24 h-24 rounded-full bg-kolping-500/10 flex items-center justify-center mb-4'>
-            <svg className='w-12 h-12 text-kolping-500/50' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
-              <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1.5} d='M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' />
-            </svg>
-          </div>
-          <h2 className='text-2xl font-bold text-site-200'>Noch keine Bilder vorhanden</h2>
-          <p className='text-site-400 max-w-md'>
-            Für diese Aufführung sind momentan noch keine Bilder in der Galerie verfügbar. 
-            Bitte schauen Sie später noch einmal vorbei.
-          </p>
-        </div>
-      </div>
-    )
-  }
+  const title = timelineEntry?.header || playData?.play || play
+  const dateRaw = timelineEntry?.date || (playData?.year ? String(playData.year) : '')
+  const { month, year } = parseDateParts(dateRaw)
+  const location = playData?.location || null
+  const locationLabel =
+    location === 'Open-Air-Bühne'
+      ? 'Open-Air'
+      : location === 'Kreativbühne'
+        ? 'Kreativbühne'
+        : null
+  const heroImage = timelineEntry?.image ? `/img/${timelineEntry.image}` : '/img/home_team.jpg'
 
   return (
-    <div className='space-y-8 sm:space-y-12 md:space-y-16'>
-      {renderHero(
-        <>
-          Entdecken Sie die <span className='text-kolping-400'>Highlights</span> dieser Produktion – 
-          {metas!.length} unvergessliche Momente.
-        </>
-      )}
+    <div className='space-y-0'>
+      <section className='relative -mx-4 -mt-8 overflow-hidden'>
+        <div className='relative w-full h-[72vh] min-h-[460px] max-h-[820px]'>
+          <Image
+            src={heroImage}
+            alt={title}
+            fill
+            priority
+            sizes='100vw'
+            className='absolute inset-0 h-full w-full object-cover'
+          />
+          <div className='absolute inset-0 bg-gradient-to-b from-site-950/30 via-site-950/35 to-site-950' />
+          <div className='absolute inset-0 bg-gradient-to-r from-site-950/60 via-transparent to-site-950/40' />
+          <div className='vignette' />
 
-      {/* Gallery Grid Section */}
-      <section>
-        {/* Section Divider */}
-        <div className='relative py-8 sm:py-12'>
-          <div className='relative text-center space-y-3'>
-            <div className='flex items-center justify-center gap-4'>
-              {/* Left decorative flourish */}
-              <div className='hidden sm:flex items-center gap-2'>
-                <div className='w-8 h-px bg-gradient-to-l from-kolping-500 to-transparent' />
-                <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
-                <div className='w-16 h-px bg-gradient-to-l from-kolping-500/80 to-transparent' />
-              </div>
-              
-              <h2 className='font-display text-2xl sm:text-3xl md:text-4xl font-extrabold tracking-tight text-kolping-400 drop-shadow-[0_0_20px_rgba(255,122,0,0.3)]'>
-                Fotogalerie
-              </h2>
-              
-              {/* Right decorative flourish */}
-              <div className='hidden sm:flex items-center gap-2'>
-                <div className='w-16 h-px bg-gradient-to-r from-kolping-500/80 to-transparent' />
-                <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
-                <div className='w-8 h-px bg-gradient-to-r from-kolping-500 to-transparent' />
+          <div className='absolute inset-0'>
+            <div className='mx-auto max-w-6xl px-4 pt-8'>
+              <Link
+                href='/gallery'
+                className='inline-flex items-center gap-2 text-site-100 hover:text-kolping-400 transition-colors group'
+              >
+                <svg className='w-5 h-5 transition-transform group-hover:-translate-x-1' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M15 19l-7-7 7-7' />
+                </svg>
+                <span className='text-sm font-medium'>Zurück zur Galerie</span>
+              </Link>
+            </div>
+
+            <div className='absolute inset-x-0 bottom-0 pb-10 sm:pb-14 md:pb-16'>
+              <div className='mx-auto max-w-6xl px-4'>
+                <div className='mb-4 flex flex-wrap items-center gap-2.5'>
+                  {dateRaw && (
+                    <span className='inline-flex items-center rounded-full border border-kolping-400/40 bg-site-950/60 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.16em] text-kolping-400 uppercase'>
+                      {month} {year}
+                    </span>
+                  )}
+                  {locationLabel && (
+                    <span className='inline-flex items-center rounded-full border border-white/20 bg-site-950/55 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.14em] text-site-100 uppercase'>
+                      {locationLabel}
+                    </span>
+                  )}
+                  {hasImages && (
+                    <span className='inline-flex items-center rounded-full border border-white/20 bg-site-950/55 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.14em] text-site-100 uppercase'>
+                      {metas!.length} Fotos
+                    </span>
+                  )}
+                </div>
+
+                <h1
+                  className='font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black tracking-tight leading-[0.94] text-shadow-lg'
+                  style={{ viewTransitionName: `gallery-title-${play}` }}
+                >
+                  <span className='text-site-50'>{title}</span>
+                </h1>
+
+                <p className='mt-4 sm:mt-6 text-base sm:text-lg md:text-xl text-site-100/90 max-w-2xl leading-relaxed text-shadow'>
+                  {hasImages
+                    ? 'Alle verfügbaren Szenen dieser Produktion in einer zusammenhängenden Galerie.'
+                    : 'Für diese Produktion sind aktuell noch keine Bilder veröffentlicht.'}
+                </p>
               </div>
             </div>
-            
-            <p className='text-site-100 text-sm sm:text-base max-w-lg mx-auto'>
-              Klicken Sie auf ein Bild, um es in voller Größe zu betrachten
-            </p>
           </div>
         </div>
-        
-        <ClientGrid play={play} metas={metas!} captions={captions!} />
+      </section>
+
+      {!hasImages ? (
+        <section className='mx-auto max-w-6xl px-4 py-12 sm:py-16'>
+          <div className='glass rounded-2xl border border-site-700 p-8 sm:p-10 text-center'>
+            <div className='mx-auto w-16 h-16 rounded-full bg-kolping-500/10 border border-kolping-500/30 flex items-center justify-center mb-5'>
+              <svg className='w-8 h-8 text-kolping-400' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1.5} d='M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' />
+              </svg>
+            </div>
+            <h2 className='font-display text-2xl sm:text-3xl font-bold text-site-50'>
+              Noch keine Galerie verfügbar
+            </h2>
+            <p className='mt-2 text-site-100 max-w-lg mx-auto'>
+              Sobald Bilder zu dieser Produktion veröffentlicht sind, erscheinen sie hier.
+            </p>
+            <div className='mt-6 flex justify-center gap-3'>
+              <Link
+                href='/gallery'
+                className='inline-flex items-center gap-2 rounded-full bg-kolping-400 px-5 py-2.5 text-sm font-bold text-white transition-all hover:bg-kolping-500'
+              >
+                Alle Produktionen
+              </Link>
+              <Link
+                href='/about'
+                className='inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/50 px-5 py-2.5 text-sm font-medium transition-all hover:border-kolping-400/50 hover:bg-site-800'
+              >
+                Zur Chronik
+              </Link>
+            </div>
+          </div>
+        </section>
+      ) : (
+        <section className='mx-auto max-w-6xl px-4 py-8 sm:py-10'>
+          <div className='rounded-xl border border-site-700 bg-site-800/50 p-4 sm:p-5 text-sm text-site-100'>
+            Tipp: Klicke auf ein Bild, um es im Lightbox-Modus in voller Größe zu öffnen.
+          </div>
+
+          <SectionDivider
+            title='Fotogalerie'
+            subtitle='Szenen, Details und Momente dieser Aufführung'
+          />
+
+          <div className='glass border border-site-700 rounded-2xl p-3 sm:p-4 md:p-6'>
+            <ClientGrid play={play} metas={metas!} captions={captions!} />
+          </div>
+        </section>
+      )}
+
+      <section className='mx-auto max-w-6xl px-4 pb-12 sm:pb-16'>
+        <div className='relative overflow-hidden rounded-2xl border border-site-700'>
+          <div className='absolute inset-0 bg-gradient-to-br from-kolping-400/10 via-site-900 to-site-900' />
+          <div className='relative p-6 sm:p-8 md:p-10 flex flex-col sm:flex-row items-center justify-between gap-4'>
+            <p className='text-sm sm:text-base text-site-100 text-center sm:text-left'>
+              Weitere Produktionen oder das Team hinter dem Stück entdecken.
+            </p>
+            <div className='flex items-center gap-3'>
+              <Link
+                href='/gallery'
+                className='inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/60 px-5 py-2.5 text-sm font-medium transition-all hover:border-kolping-400/50 hover:bg-site-800'
+              >
+                Zur Galerie
+              </Link>
+              <Link
+                href='/team'
+                className='inline-flex items-center gap-2 rounded-full bg-kolping-400 px-5 py-2.5 text-sm font-bold text-white transition-all hover:bg-kolping-500'
+              >
+                Zum Team
+              </Link>
+            </div>
+          </div>
+        </div>
       </section>
     </div>
   )

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -162,8 +162,6 @@ export default function GalleryPage() {
     return acc
   }, {})
   const years = Object.keys(yearGroups)
-  const openAirCount = shows.filter((show) => show.location === 'Open-Air-Bühne').length
-  const kreativCount = shows.filter((show) => show.location === 'Kreativbühne').length
   const latestShow = shows[0]
 
   return (
@@ -209,39 +207,16 @@ export default function GalleryPage() {
       </section>
 
       <section className='relative -mx-4 border-y border-site-700 bg-site-900'>
-        <div className='mx-auto max-w-6xl px-4 py-6 sm:py-8'>
-          <div className='grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-8 text-center'>
-            <div>
-              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
-                {shows.length}
-              </div>
-              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
-                Produktionen
-              </div>
+        <div className='mx-auto max-w-6xl px-4 py-5 sm:py-6'>
+          <div className='grid sm:grid-cols-3 gap-3 sm:gap-4'>
+            <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
+              Archiv: Alle verfügbaren Produktionen nach Jahr geordnet.
             </div>
-            <div>
-              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
-                {years.length}
-              </div>
-              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
-                Jahrgänge
-              </div>
+            <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
+              Schnellzugriff: Über die Jahresleiste direkt zur gewünschten Saison springen.
             </div>
-            <div>
-              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
-                {openAirCount}
-              </div>
-              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
-                Open-Air
-              </div>
-            </div>
-            <div>
-              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
-                {kreativCount}
-              </div>
-              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
-                Kreativbühne
-              </div>
+            <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
+              Detailansicht: In jeder Produktion stehen Fotos im Lightbox-Modus bereit.
             </div>
           </div>
         </div>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -156,13 +156,8 @@ export default function GalleryPage() {
       }
     })
 
-  const yearGroups = shows.reduce<Record<string, TimelineShow[]>>((acc, show) => {
-    if (!acc[show.year]) acc[show.year] = []
-    acc[show.year].push(show)
-    return acc
-  }, {})
-  const years = Object.keys(yearGroups)
   const latestShow = shows[0]
+  const [featuredShow, ...restShows] = shows
 
   return (
     <div className='space-y-0'>
@@ -224,66 +219,24 @@ export default function GalleryPage() {
 
       <section className='mx-auto max-w-6xl px-4 py-8 sm:py-10'>
         <SectionDivider
-          title='Produktionen nach Jahr'
-          subtitle='Schneller Zugriff auf jede Spielzeit'
+          title='Produktionen'
+          subtitle='Alle verfügbaren Galerien in chronologischer Reihenfolge'
         />
 
-        <div className='sticky top-[72px] z-20 backdrop-blur supports-[backdrop-filter]:bg-site-900/55 bg-site-900/75 rounded-xl border border-site-700/60 p-3'>
-          <div className='flex items-center gap-2 overflow-x-auto scrollbar-thin'>
-            {years.map((year) => (
-              <a
-                key={year}
-                href={`#gallery-year-${year}`}
-                className='shrink-0 inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/80 px-3 py-1.5 text-xs text-site-100 hover:border-kolping-400/60 hover:text-kolping-400 transition-colors'
-              >
-                <span className='font-semibold'>{year}</span>
-                <span className='inline-flex min-w-5 h-5 items-center justify-center rounded-full bg-site-700 text-[10px] text-site-100'>
-                  {yearGroups[year].length}
-                </span>
-              </a>
-            ))}
-          </div>
-        </div>
+        <div className='space-y-6 sm:space-y-8'>
+          {featuredShow && <GalleryCard show={featuredShow} index={0} isHero />}
 
-        <div className='pt-8 sm:pt-10 space-y-12 sm:space-y-14'>
-          {years.map((year, yearIndex) => {
-            const group = yearGroups[year]
-            const [hero, ...rest] = group
-            const hasFeatured = yearIndex === 0 && !!hero
-            const gridItems = hasFeatured ? rest : group
-
-            return (
-              <section
-                key={year}
-                id={`gallery-year-${year}`}
-                className='scroll-mt-32 space-y-4'
-              >
-                <div className='flex items-center gap-3'>
-                  <h2 className='font-display text-3xl sm:text-4xl font-black text-kolping-400 tracking-tight'>
-                    {year}
-                  </h2>
-                  <div className='h-px flex-1 bg-gradient-to-r from-kolping-500/50 to-transparent' />
-                  <span className='rounded-full border border-site-700 bg-site-800/70 px-3 py-1 text-xs text-site-100'>
-                    {group.length} Produktionen
-                  </span>
-                </div>
-
-                {hasFeatured && hero && <GalleryCard show={hero} index={yearIndex} isHero />}
-
-                {gridItems.length > 0 && (
-                  <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6'>
-                    {gridItems.map((show, index) => (
-                      <GalleryCard
-                        key={show.galleryHash}
-                        show={show}
-                        index={yearIndex * 10 + index}
-                      />
-                    ))}
-                  </div>
-                )}
-              </section>
-            )
-          })}
+          {restShows.length > 0 && (
+            <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6'>
+              {restShows.map((show, index) => (
+                <GalleryCard
+                  key={show.galleryHash}
+                  show={show}
+                  index={index + 1}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </section>
 

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -92,7 +92,7 @@ function GalleryCard({
         <div className='absolute -inset-4 bg-gradient-to-b from-kolping-500/20 via-kolping-500/5 to-transparent rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl pointer-events-none' />
 
         <div
-          className={`relative overflow-hidden bg-site-800 ${isHero ? 'aspect-[21/9] sm:aspect-[16/8] md:aspect-[16/6]' : 'aspect-[3/4]'}`}
+          className={`relative overflow-hidden bg-site-800 ${isHero ? 'aspect-[21/9] sm:aspect-[16/8] md:aspect-[16/6]' : 'aspect-[16/10]'}`}
           style={{ backgroundColor: show.dominantColor }}
         >
           <Image
@@ -117,7 +117,7 @@ function GalleryCard({
           </div>
 
           <div className='absolute bottom-0 inset-x-0 p-4 sm:p-5 z-20'>
-            <h3 className={`font-display font-black text-white drop-shadow-lg group-hover:text-kolping-400 transition-colors duration-300 ${isHero ? 'text-2xl sm:text-3xl md:text-4xl' : 'text-lg sm:text-xl'}`}>
+            <h3 className={`font-display font-black text-white drop-shadow-lg group-hover:text-kolping-400 transition-colors duration-300 ${isHero ? 'text-2xl sm:text-3xl md:text-4xl' : 'text-base sm:text-lg md:text-xl'}`}>
               {show.header}
             </h3>
             <div className='mt-2 flex items-center gap-2 text-sm text-white/80 group-hover:text-kolping-400 transition-colors'>
@@ -171,7 +171,7 @@ export default function GalleryPage() {
       <section className='relative -mx-4 -mt-8 overflow-hidden'>
         <div className='relative w-full h-[72vh] min-h-[460px] max-h-[820px]'>
           <Image
-            src={latestShow ? `/img/${latestShow.image}` : '/img/home_team.jpg'}
+            src='/img/home_team.jpg'
             alt={latestShow ? `Aktuelle Produktion: ${latestShow.header}` : 'Galerie des Kolpingtheaters Ramsen'}
             fill
             priority
@@ -274,6 +274,8 @@ export default function GalleryPage() {
           {years.map((year, yearIndex) => {
             const group = yearGroups[year]
             const [hero, ...rest] = group
+            const hasFeatured = yearIndex === 0 && !!hero
+            const gridItems = hasFeatured ? rest : group
 
             return (
               <section
@@ -291,11 +293,11 @@ export default function GalleryPage() {
                   </span>
                 </div>
 
-                {hero && <GalleryCard show={hero} index={yearIndex} isHero />}
+                {hasFeatured && hero && <GalleryCard show={hero} index={yearIndex} isHero />}
 
-                {rest.length > 0 && (
+                {gridItems.length > 0 && (
                   <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6'>
-                    {rest.map((show, index) => (
+                    {gridItems.map((show, index) => (
                       <GalleryCard
                         key={show.galleryHash}
                         show={show}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -205,10 +205,12 @@ export default function GalleryPage() {
         <div className='mx-auto max-w-6xl px-4 py-5 sm:py-6'>
           <div className='grid sm:grid-cols-3 gap-3 sm:gap-4'>
             <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
-              Archiv: Alle verfügbaren Produktionen nach Jahr geordnet.
+              Archiv: Alle verfügbaren Produktionen in einer durchgehenden
+              Übersicht.
             </div>
             <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
-              Schnellzugriff: Über die Jahresleiste direkt zur gewünschten Saison springen.
+              Schnellzugriff: Neueste Stücke zuerst, ältere Produktionen direkt
+              darunter.
             </div>
             <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
               Detailansicht: In jeder Produktion stehen Fotos im Lightbox-Modus bereit.

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import timeline from '@/data/timeline.json'
+import teamData from '@/data/team.json'
 
 type TimelineEntry = {
   date: string
@@ -11,85 +12,123 @@ type TimelineEntry = {
   dominantColor?: string
 }
 
-// Gallery card with theatrical effects
-function GalleryCard({ 
-  show, 
-  index 
-}: { 
-  show: TimelineEntry
-  index: number 
+type TimelineShow = TimelineEntry & {
+  year: string
+  month: string
+  location?: string | null
+}
+
+type Play = {
+  slug: string | null
+  location: string | null
+}
+
+function parseDateParts(date: string) {
+  const parts = date.trim().split(' ').filter(Boolean)
+  const year = parts[parts.length - 1] ?? date
+  const month = parts.slice(0, -1).join(' ') || date
+  return { month, year }
+}
+
+function SectionDivider({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className='relative py-8 sm:py-12'>
+      <div className='relative text-center space-y-3'>
+        <div className='flex items-center justify-center gap-4'>
+          <div className='hidden sm:flex items-center gap-2'>
+            <div className='w-8 h-px bg-gradient-to-l from-kolping-500 to-transparent' />
+            <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
+            <div className='w-16 h-px bg-gradient-to-l from-kolping-500/80 to-transparent' />
+          </div>
+
+          <h2 className='font-display text-2xl sm:text-3xl md:text-4xl font-extrabold tracking-tight text-kolping-400 drop-shadow-[0_0_20px_rgba(255,122,0,0.3)]'>
+            {title}
+          </h2>
+
+          <div className='hidden sm:flex items-center gap-2'>
+            <div className='w-16 h-px bg-gradient-to-r from-kolping-500/80 to-transparent' />
+            <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
+            <div className='w-8 h-px bg-gradient-to-r from-kolping-500 to-transparent' />
+          </div>
+        </div>
+
+        {subtitle && (
+          <p className='text-site-100 text-sm sm:text-base max-w-xl mx-auto'>
+            {subtitle}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function GalleryCard({
+  show,
+  index,
+  isHero,
+}: {
+  show: TimelineShow
+  index: number
+  isHero?: boolean
 }) {
+  const locationLabel =
+    show.location === 'Open-Air-Bühne'
+      ? 'Open-Air'
+      : show.location === 'Kreativbühne'
+        ? 'Kreativbühne'
+        : null
+
   return (
     <Link
       href={`/gallery/${show.galleryHash}`}
       className='group relative block'
       aria-label={`Galerie ansehen: ${show.header}`}
-      style={{ 
-        viewTransitionName: `gallery-${show.galleryHash}`,
-        animationDelay: `${index * 50}ms`,
-      }}
+      style={{ viewTransitionName: `gallery-${show.galleryHash}` }}
     >
-      {/* Card container with epic glow */}
-      <div className='
-        relative poster-frame border-epic bg-site-800 
-        transition-all duration-500 ease-out
-        hover:scale-[1.03] hover:-translate-y-2
-        animate-fade-in-up
-      '>
-        {/* Theatrical spotlight glow on hover */}
+      <div
+        className='relative poster-frame border-epic bg-site-800 transition-all duration-500 ease-out hover:scale-[1.02] hover:-translate-y-1 animate-fade-in-up'
+        style={{ animationDelay: `${index * 35}ms` }}
+      >
         <div className='absolute -inset-4 bg-gradient-to-b from-kolping-500/20 via-kolping-500/5 to-transparent rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl pointer-events-none' />
-        
-        {/* Image container */}
-        <div className='relative aspect-[3/4] overflow-hidden bg-site-800'>
-          {/* Animated spotlight beam */}
-          <div className='absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-700 pointer-events-none z-10'>
-            <div className='absolute top-0 left-1/2 -translate-x-1/2 w-full h-full bg-gradient-to-b from-kolping-500/20 via-transparent to-transparent' />
-          </div>
-          
+
+        <div
+          className={`relative overflow-hidden bg-site-800 ${isHero ? 'aspect-[21/9] sm:aspect-[16/8] md:aspect-[16/6]' : 'aspect-[3/4]'}`}
+          style={{ backgroundColor: show.dominantColor }}
+        >
           <Image
             src={`/img/${show.image}`}
             alt={show.header}
             fill
-            className='object-cover transition-all duration-700 ease-out group-hover:scale-110 group-hover:brightness-110'
-            style={{ 
-              viewTransitionName: `gallery-image-${show.galleryHash}`,
-            }}
+            className={`transition-all duration-700 ease-out group-hover:scale-105 group-hover:brightness-110 ${isHero ? 'object-cover' : 'object-cover object-center'}`}
+            style={{ viewTransitionName: `gallery-image-${show.galleryHash}` }}
           />
-          
-          {/* Dramatic gradient overlays */}
-          <div className='absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black via-black/60 to-transparent z-10' />
-          <div className='absolute inset-0 bg-gradient-to-r from-black/20 via-transparent to-black/20 z-10' />
-          
-          {/* Year badge */}
-          <div className='absolute top-3 right-3 z-20'>
-            <div className='px-2.5 py-1 rounded-full bg-black/70 backdrop-blur-sm border border-kolping-500/40'>
-              <span className='text-[10px] font-bold uppercase tracking-wider text-kolping-400 font-mono'>{show.date}</span>
-            </div>
-          </div>
-          
-          {/* Title overlay on image */}
-          <div className='absolute bottom-0 inset-x-0 p-4 z-20'>
-            <h2 className='font-display font-bold text-lg sm:text-xl text-white group-hover:text-kolping-400 transition-colors duration-300 drop-shadow-lg'>
-              {show.header}
-            </h2>
-            <div className='flex items-center gap-2 mt-1'>
-              <div className='w-6 h-0.5 bg-kolping-500 rounded-full transition-all duration-500 group-hover:w-12' />
-              <span className='text-xs text-white/70 font-medium'>
-                Galerie ansehen
+          <div className='absolute inset-0 bg-gradient-to-t from-black/85 via-black/20 to-transparent z-10' />
+          <div className='absolute inset-0 bg-gradient-to-r from-black/20 via-transparent to-black/15 z-10' />
+
+          <div className='absolute top-3 left-3 z-20 flex items-center gap-2'>
+            <span className='rounded-full border border-kolping-500/45 bg-black/65 backdrop-blur-sm px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.15em] text-kolping-400'>
+              {show.month} {show.year}
+            </span>
+            {locationLabel && (
+              <span className='rounded-full border border-site-700 bg-site-900/80 backdrop-blur-sm px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-site-100'>
+                {locationLabel}
               </span>
-              <svg 
-                className='w-4 h-4 text-kolping-400 transition-transform duration-300 group-hover:translate-x-1' 
-                fill='none' 
-                viewBox='0 0 24 24' 
-                stroke='currentColor'
-              >
+            )}
+          </div>
+
+          <div className='absolute bottom-0 inset-x-0 p-4 sm:p-5 z-20'>
+            <h3 className={`font-display font-black text-white drop-shadow-lg group-hover:text-kolping-400 transition-colors duration-300 ${isHero ? 'text-2xl sm:text-3xl md:text-4xl' : 'text-lg sm:text-xl'}`}>
+              {show.header}
+            </h3>
+            <div className='mt-2 flex items-center gap-2 text-sm text-white/80 group-hover:text-kolping-400 transition-colors'>
+              Galerie öffnen
+              <svg className='w-4 h-4 transition-transform group-hover:translate-x-1' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
                 <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M13 7l5 5m0 0l-5 5m5-5H6' />
               </svg>
             </div>
           </div>
         </div>
-        
-        {/* Bottom accent bar */}
+
         <div className='h-1 bg-gradient-to-r from-transparent via-kolping-500/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500' />
       </div>
     </Link>
@@ -97,84 +136,218 @@ function GalleryCard({
 }
 
 export default function GalleryPage() {
-  const shows = (timeline as unknown as TimelineEntry[])
-    .filter((t) => t.image && t.galleryHash)
+  const plays = (teamData as { plays: Play[] }).plays
+  const locationBySlug = new Map<string, string | null>(
+    plays
+      .filter((play): play is Play & { slug: string } => !!play.slug)
+      .map((play) => [play.slug, play.location]),
+  )
+
+  const shows: TimelineShow[] = (timeline as TimelineEntry[])
+    .filter((entry): entry is TimelineEntry & Required<Pick<TimelineEntry, 'image' | 'galleryHash'>> => !!entry.image && !!entry.galleryHash)
     .reverse()
+    .map((entry) => {
+      const { month, year } = parseDateParts(entry.date)
+      return {
+        ...entry,
+        month,
+        year,
+        location: locationBySlug.get(entry.galleryHash) ?? null,
+      }
+    })
+
+  const yearGroups = shows.reduce<Record<string, TimelineShow[]>>((acc, show) => {
+    if (!acc[show.year]) acc[show.year] = []
+    acc[show.year].push(show)
+    return acc
+  }, {})
+  const years = Object.keys(yearGroups)
+  const openAirCount = shows.filter((show) => show.location === 'Open-Air-Bühne').length
+  const kreativCount = shows.filter((show) => show.location === 'Kreativbühne').length
+  const latestShow = shows[0]
 
   return (
-    <div className='space-y-8 sm:space-y-12 md:space-y-16'>
-      {/* Epic Hero Section */}
-      <section className='relative -mt-8 pt-8 pb-12 sm:pb-16 overflow-hidden'>
-        {/* Background theatrical elements */}
-        <div className='absolute inset-0 pointer-events-none'>
-          {/* Stage spotlights */}
-          <div className='absolute top-0 left-1/4 w-96 h-96 bg-gradient-radial from-kolping-500/10 to-transparent blur-3xl' />
-          <div className='absolute top-0 right-1/4 w-96 h-96 bg-gradient-radial from-kolping-500/10 to-transparent blur-3xl' />
-        </div>
-        
-        <div className='relative text-center space-y-6'>
-          {/* Decorative top element */}
-          <div className='flex justify-center'>
-            <div className='relative'>
-              <div className='absolute -inset-4 bg-kolping-500/20 blur-2xl rounded-full' />
-              <svg className='relative w-12 h-12 text-kolping-500' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
-                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1} d='M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' />
-              </svg>
+    <div className='space-y-0'>
+      <section className='relative -mx-4 -mt-8 overflow-hidden'>
+        <div className='relative w-full h-[72vh] min-h-[460px] max-h-[820px]'>
+          <Image
+            src={latestShow ? `/img/${latestShow.image}` : '/img/home_team.jpg'}
+            alt={latestShow ? `Aktuelle Produktion: ${latestShow.header}` : 'Galerie des Kolpingtheaters Ramsen'}
+            fill
+            priority
+            sizes='100vw'
+            className='object-cover'
+          />
+          <div className='absolute inset-0 bg-gradient-to-b from-site-950/35 via-site-950/30 to-site-950' />
+          <div className='absolute inset-0 bg-gradient-to-r from-site-950/60 via-transparent to-site-950/35' />
+          <div className='vignette' />
+
+          <div className='absolute inset-0 flex flex-col justify-end pb-10 sm:pb-14 md:pb-16'>
+            <div className='mx-auto w-full max-w-6xl px-4'>
+              <div className='animate-fade-in-up mb-4 flex flex-wrap gap-2.5'>
+                <span className='inline-flex items-center rounded-full border border-kolping-400/40 bg-site-950/60 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.16em] text-kolping-400 uppercase'>
+                  Fotoarchive
+                </span>
+                <span className='inline-flex items-center rounded-full border border-white/20 bg-site-950/55 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.14em] text-site-100 uppercase'>
+                  Open-Air & Kreativbühne
+                </span>
+              </div>
+
+              <h1 className='animate-fade-in-up font-display text-4xl sm:text-6xl md:text-7xl lg:text-8xl font-black tracking-tight leading-[0.92] text-shadow-lg'>
+                Unsere Galerie
+                <br />
+                <span className='text-kolping-400'>Produktionen im Rückblick</span>
+              </h1>
+
+              <p className='animate-fade-in-up mt-4 sm:mt-6 text-base sm:text-lg md:text-xl text-site-100/90 max-w-2xl leading-relaxed text-shadow'>
+                Entdecke die wichtigsten Momente unserer Stücke von den ersten
+                Open-Air-Abenden bis zu den neuesten Winterproduktionen.
+              </p>
             </div>
           </div>
-          
-          <h1 className='font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black tracking-tight'>
-            <span className='text-kolping-400 drop-shadow-[0_0_30px_rgba(255,122,0,0.4)]'>Unsere</span>{' '}
-            <span className='text-site-50'>Galerie</span>
-          </h1>
-          
-          <p className='text-site-100 text-base sm:text-lg max-w-2xl mx-auto leading-relaxed'>
-            Tauchen Sie ein in unsere vergangenen Aufführungen und erleben Sie die 
-            <span className='text-kolping-400'> Magie des Theaters</span> – 
-            festgehalten in unvergesslichen Momenten.
-          </p>
         </div>
       </section>
 
-      {/* Gallery Grid */}
-      <section>
-        {/* Section Divider */}
-        <div className='relative py-8 sm:py-12'>
-          <div className='relative text-center space-y-3'>
-            <div className='flex items-center justify-center gap-4'>
-              {/* Left decorative flourish */}
-              <div className='hidden sm:flex items-center gap-2'>
-                <div className='w-8 h-px bg-gradient-to-l from-kolping-500 to-transparent' />
-                <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
-                <div className='w-16 h-px bg-gradient-to-l from-kolping-500/80 to-transparent' />
+      <section className='relative -mx-4 border-y border-site-700 bg-site-900'>
+        <div className='mx-auto max-w-6xl px-4 py-6 sm:py-8'>
+          <div className='grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-8 text-center'>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {shows.length}
               </div>
-              
-              <h2 className='font-display text-2xl sm:text-3xl md:text-4xl font-extrabold tracking-tight text-kolping-400 drop-shadow-[0_0_20px_rgba(255,122,0,0.3)]'>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
                 Produktionen
-              </h2>
-              
-              {/* Right decorative flourish */}
-              <div className='hidden sm:flex items-center gap-2'>
-                <div className='w-16 h-px bg-gradient-to-r from-kolping-500/80 to-transparent' />
-                <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
-                <div className='w-8 h-px bg-gradient-to-r from-kolping-500 to-transparent' />
               </div>
             </div>
-            
-            <p className='text-site-100 text-sm sm:text-base max-w-lg mx-auto'>
-              Wählen Sie eine Produktion, um die Fotogalerie zu erkunden
-            </p>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {years.length}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Jahrgänge
+              </div>
+            </div>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {openAirCount}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Open-Air
+              </div>
+            </div>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {kreativCount}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Kreativbühne
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className='mx-auto max-w-6xl px-4 py-8 sm:py-10'>
+        <SectionDivider
+          title='Produktionen nach Jahr'
+          subtitle='Schneller Zugriff auf jede Spielzeit'
+        />
+
+        <div className='sticky top-[72px] z-20 backdrop-blur supports-[backdrop-filter]:bg-site-900/55 bg-site-900/75 rounded-xl border border-site-700/60 p-3'>
+          <div className='flex items-center gap-2 overflow-x-auto scrollbar-thin'>
+            {years.map((year) => (
+              <a
+                key={year}
+                href={`#gallery-year-${year}`}
+                className='shrink-0 inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/80 px-3 py-1.5 text-xs text-site-100 hover:border-kolping-400/60 hover:text-kolping-400 transition-colors'
+              >
+                <span className='font-semibold'>{year}</span>
+                <span className='inline-flex min-w-5 h-5 items-center justify-center rounded-full bg-site-700 text-[10px] text-site-100'>
+                  {yearGroups[year].length}
+                </span>
+              </a>
+            ))}
           </div>
         </div>
 
-        <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6'>
-          {shows.map((show, index) => (
-            <GalleryCard 
-              key={show.galleryHash} 
-              show={show} 
-              index={index} 
-            />
-          ))}
+        <div className='pt-8 sm:pt-10 space-y-12 sm:space-y-14'>
+          {years.map((year, yearIndex) => {
+            const group = yearGroups[year]
+            const [hero, ...rest] = group
+
+            return (
+              <section
+                key={year}
+                id={`gallery-year-${year}`}
+                className='scroll-mt-32 space-y-4'
+              >
+                <div className='flex items-center gap-3'>
+                  <h2 className='font-display text-3xl sm:text-4xl font-black text-kolping-400 tracking-tight'>
+                    {year}
+                  </h2>
+                  <div className='h-px flex-1 bg-gradient-to-r from-kolping-500/50 to-transparent' />
+                  <span className='rounded-full border border-site-700 bg-site-800/70 px-3 py-1 text-xs text-site-100'>
+                    {group.length} Produktionen
+                  </span>
+                </div>
+
+                {hero && <GalleryCard show={hero} index={yearIndex} isHero />}
+
+                {rest.length > 0 && (
+                  <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6'>
+                    {rest.map((show, index) => (
+                      <GalleryCard
+                        key={show.galleryHash}
+                        show={show}
+                        index={yearIndex * 10 + index}
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
+            )
+          })}
+        </div>
+      </section>
+
+      <section className='mx-auto max-w-6xl px-4 py-12 sm:py-16'>
+        <div className='relative overflow-hidden rounded-2xl border border-site-700'>
+          <div className='absolute inset-0 bg-gradient-to-br from-kolping-400/10 via-site-900 to-site-900' />
+          <div className='absolute top-0 right-0 w-1/2 h-full bg-gradient-to-l from-kolping-400/[0.05] to-transparent' />
+
+          <div className='relative p-8 sm:p-10 md:p-14 flex flex-col md:flex-row items-center gap-8 md:gap-12'>
+            <div className='flex-1 text-center md:text-left'>
+              <span className='block text-[11px] sm:text-xs tracking-[0.2em] uppercase text-kolping-400 font-semibold mb-3'>
+                Mehr entdecken
+              </span>
+              <h2 className='font-display text-2xl sm:text-3xl md:text-4xl font-black tracking-tight leading-tight'>
+                Hinter den Bildern
+                <br className='hidden sm:block' />
+                steckt das Team
+              </h2>
+              <p className='text-site-100 mt-3 sm:mt-4 text-sm sm:text-base max-w-md leading-relaxed'>
+                Schau dir an, wer die Produktionen auf, vor und hinter der
+                Bühne möglich macht.
+              </p>
+            </div>
+            <div className='flex flex-col sm:flex-row items-center gap-3'>
+              <Link
+                href='/team'
+                className='group inline-flex items-center gap-2.5 rounded-full bg-kolping-400 px-6 py-3 text-sm font-bold text-white transition-all hover:bg-kolping-500 hover:shadow-[0_0_30px_rgba(255,122,0,0.3)]'
+              >
+                Zum Team
+                <svg className='w-4 h-4 transition-transform group-hover:translate-x-0.5' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
+                </svg>
+              </Link>
+              <Link
+                href='/about'
+                className='inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/50 px-6 py-3 text-sm font-medium transition-all hover:border-kolping-400/50 hover:bg-site-800'
+              >
+                Chronik ansehen
+              </Link>
+            </div>
+          </div>
         </div>
       </section>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -199,6 +199,7 @@ img {
   content: '';
   position: absolute;
   inset: 0;
+  pointer-events: none;
   border-radius: inherit;
   padding: 1px;
   background: linear-gradient(120deg, rgba(255, 122, 0, 0.4), rgba(255, 200, 140, 0.2), rgba(255, 122, 0, 0.4));

--- a/src/app/team/[person]/page.tsx
+++ b/src/app/team/[person]/page.tsx
@@ -176,7 +176,9 @@ export default async function PersonPage({
             <span className='text-sm font-medium'>Zurück zum Team</span>
           </Link>
 
-          <div className='mt-6 grid lg:grid-cols-[1.1fr_0.9fr] gap-6 lg:gap-10 items-end'>
+          <div
+            className={`mt-6 grid gap-6 lg:gap-10 items-end ${hasPlaceholder ? '' : 'lg:grid-cols-[1.1fr_0.9fr]'}`}
+          >
             <div>
               <div className='flex flex-wrap items-center gap-2 mb-4'>
                 <span className='inline-flex items-center rounded-full border border-kolping-400/40 bg-site-950/60 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.16em] text-kolping-400 uppercase'>
@@ -203,19 +205,20 @@ export default async function PersonPage({
               </p>
             </div>
 
-            <div style={{ viewTransitionName: `person-${person.id}` }}>
-              <div className='relative poster-frame border-epic overflow-hidden'>
-                <div className='relative aspect-[3/4] w-full'>
-                  <Slideshow
-                    name={person.id}
-                    count={imageCount}
-                    aspect='hero'
-                    placeholder={hasPlaceholder}
-                  />
-                  <div className='absolute inset-0 bg-gradient-to-t from-black/50 to-transparent pointer-events-none' />
+            {!hasPlaceholder && (
+              <div style={{ viewTransitionName: `person-${person.id}` }}>
+                <div className='relative poster-frame border-epic overflow-hidden'>
+                  <div className='relative aspect-[3/4] w-full'>
+                    <Slideshow
+                      name={person.id}
+                      count={imageCount}
+                      aspect='hero'
+                    />
+                    <div className='absolute inset-0 bg-gradient-to-t from-black/50 to-transparent pointer-events-none' />
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         </div>
       </section>

--- a/src/app/team/[person]/page.tsx
+++ b/src/app/team/[person]/page.tsx
@@ -1,6 +1,7 @@
 export const runtime = 'edge'
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
+import Image from 'next/image'
 import data from '@/data/team.json'
 import Slideshow from './slideshow'
 import RolesList from './roles-list'
@@ -22,63 +23,53 @@ type Play = {
   gallery: boolean
 }
 
-const plays: Play[] = (data as unknown as { plays: Play[] }).plays
+const plays: Play[] = (data as { plays: Play[] }).plays
 
 function findPerson(id: string): Entry | undefined {
   const lower = id.toLowerCase()
-  const current = (
-    (data as unknown as { current: Entry[] }).current || []
-  ).find((p) => p.id.toLowerCase() === lower)
-  const former = ((data as unknown as { former: Entry[] }).former || []).find(
-    (p) => p.id.toLowerCase() === lower
+  const current = ((data as { current: Entry[] }).current || []).find(
+    (person) => person.id.toLowerCase() === lower,
   )
-  const tech = ((data as unknown as { tech: Entry[] }).tech || []).find(
-    (p) => p.id.toLowerCase() === lower
-  ) as Entry | undefined
+  const former = ((data as { former: Entry[] }).former || []).find(
+    (person) => person.id.toLowerCase() === lower,
+  )
+  const tech = ((data as { tech: Entry[] }).tech || []).find(
+    (person) => person.id.toLowerCase() === lower,
+  )
 
   if (!current && !former && !tech) return undefined
 
   const base = current || former || tech!
-  const roles = current?.roles ?? former?.roles
-  const jobs = (tech as { jobs?: { job: string; icon?: string }[] } | undefined)
-    ?.jobs
-  const images = Math.max(
-    current?.images ?? 0,
-    former?.images ?? 0,
-    tech?.images ?? 0
-  )
-  const placeholderAvatar = Boolean(
-    current?.placeholderAvatar ||
-      former?.placeholderAvatar ||
-      tech?.placeholderAvatar
-  )
+  const images = Math.max(current?.images ?? 0, former?.images ?? 0, tech?.images ?? 0)
 
   return {
     id: base.id,
     name: base.name,
-    roles,
+    roles: current?.roles ?? former?.roles,
     images: images || base.images,
-    placeholderAvatar,
-    jobs,
+    placeholderAvatar: Boolean(current?.placeholderAvatar || former?.placeholderAvatar || tech?.placeholderAvatar),
+    jobs: tech?.jobs,
   }
 }
 
 function getPersonType(id: string): 'current' | 'former' | 'tech' | null {
   const lower = id.toLowerCase()
-  const inCurrent = ((data as unknown as { current: Entry[] }).current || [])
-    .some((p) => p.id.toLowerCase() === lower)
-  const inFormer = ((data as unknown as { former: Entry[] }).former || [])
-    .some((p) => p.id.toLowerCase() === lower)
-  const inTech = ((data as unknown as { tech: Entry[] }).tech || [])
-    .some((p) => p.id.toLowerCase() === lower)
-  
+  const inCurrent = ((data as { current: Entry[] }).current || []).some(
+    (person) => person.id.toLowerCase() === lower,
+  )
+  const inFormer = ((data as { former: Entry[] }).former || []).some(
+    (person) => person.id.toLowerCase() === lower,
+  )
+  const inTech = ((data as { tech: Entry[] }).tech || []).some(
+    (person) => person.id.toLowerCase() === lower,
+  )
+
   if (inCurrent) return 'current'
   if (inTech) return 'tech'
   if (inFormer) return 'former'
   return null
 }
 
-// Job icon component
 function JobIcon({ icon }: { icon?: string }) {
   const iconMap: Record<string, string> = {
     settings: '⚙️',
@@ -91,6 +82,38 @@ function JobIcon({ icon }: { icon?: string }) {
   return <span className='text-4xl'>{iconMap[icon || ''] || '🎭'}</span>
 }
 
+function SectionDivider({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className='relative py-8 sm:py-12'>
+      <div className='relative text-center space-y-3'>
+        <div className='flex items-center justify-center gap-4'>
+          <div className='hidden sm:flex items-center gap-2'>
+            <div className='w-8 h-px bg-gradient-to-l from-kolping-500 to-transparent' />
+            <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
+            <div className='w-16 h-px bg-gradient-to-l from-kolping-500/80 to-transparent' />
+          </div>
+
+          <h2 className='font-display text-2xl sm:text-3xl md:text-4xl font-extrabold tracking-tight text-kolping-400 drop-shadow-[0_0_20px_rgba(255,122,0,0.3)]'>
+            {title}
+          </h2>
+
+          <div className='hidden sm:flex items-center gap-2'>
+            <div className='w-16 h-px bg-gradient-to-r from-kolping-500/80 to-transparent' />
+            <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
+            <div className='w-8 h-px bg-gradient-to-r from-kolping-500 to-transparent' />
+          </div>
+        </div>
+
+        {subtitle && (
+          <p className='text-site-100 text-sm sm:text-base max-w-xl mx-auto'>
+            {subtitle}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export default async function PersonPage({
   params,
 }: {
@@ -100,117 +123,96 @@ export default async function PersonPage({
   const person = findPerson(decodeURIComponent(slug))
   if (!person) return notFound()
 
-  const hasPlaceholder = Boolean(person.placeholderAvatar)
   const personType = getPersonType(person.id)
+  const hasPlaceholder = Boolean(person.placeholderAvatar)
+  const imageCount = person.images ?? 1
 
   const rolesData = person.roles
     ? person.roles
-        .map((role, index) => ({
-          role: role!,
-          playData: plays[index]
-        }))
-        .filter((x) => x.role && x.role.trim().length > 0)
+      .map((role, index) => ({ role: role!, playData: plays[index] }))
+      .filter((item) => item.role && item.role.trim().length > 0)
     : []
 
-  const totalRoles = rolesData.length
-  const imageCount = person.images ?? 1
+  const hasRoles = rolesData.length > 0
+  const hasJobs = Boolean(person.jobs && person.jobs.length > 0)
+
+  const typeLabel =
+    personType === 'current'
+      ? 'Aktives Ensemble'
+      : personType === 'tech'
+        ? 'Technik & Crew'
+        : 'Ehemaliges Mitglied'
+
+  const heroImage = hasPlaceholder
+    ? null
+    : `/img/team/avatar/${person.id}.jpg`
 
   return (
-    <div className='min-h-screen'>
-      {/* Cinematic Hero Section */}
-      <section className='relative -mt-8 mb-12 sm:mb-16'>
+    <div className='space-y-0'>
+      <section className='relative -mx-4 -mt-8 overflow-hidden'>
+        <div className='absolute inset-0 bg-site-950'>
+          {heroImage && (
+            <Image
+              src={heroImage}
+              alt={person.name ?? person.id}
+              fill
+              priority
+              sizes='100vw'
+              className='object-cover opacity-30 blur-sm scale-105'
+            />
+          )}
+          <div className='absolute inset-0 bg-gradient-to-b from-site-950/30 via-site-950/75 to-site-950' />
+          <div className='absolute inset-0 bg-gradient-to-r from-site-950/70 via-transparent to-site-950/60' />
+        </div>
 
-        
-        {/* Back navigation */}
-        <div className='relative z-20 pt-6 pb-4 px-4 sm:px-6'>
-          <Link 
+        <div className='relative mx-auto max-w-6xl px-4 pt-8 pb-10 sm:pb-14'>
+          <Link
             href='/team'
-            className='inline-flex items-center gap-2 text-site-100 hover:text-kolping-400 transition-colors duration-300 group'
+            className='inline-flex items-center gap-2 text-site-100 hover:text-kolping-400 transition-colors group'
           >
-            <svg className='w-5 h-5 transition-transform duration-300 group-hover:-translate-x-1' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+            <svg className='w-5 h-5 transition-transform group-hover:-translate-x-1' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
               <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M15 19l-7-7 7-7' />
             </svg>
-            <span className='text-sm font-medium'>Zurück zum Ensemble</span>
+            <span className='text-sm font-medium'>Zurück zum Team</span>
           </Link>
-        </div>
-        
-        {/* Hero content container */}
-        <div className='relative px-4 sm:px-6 flex justify-center'>
-          <div 
-            className='relative w-full max-w-lg lg:max-w-xl'
-            style={{ viewTransitionName: `person-${person.id}` }}
-          >
-            {/* Main poster frame */}
-            <div className='relative poster-frame border-epic overflow-hidden'>
-              {/* Epic outer glow */}
-              <div className='absolute -inset-4 bg-gradient-to-b from-kolping-500/20 via-kolping-500/5 to-transparent rounded-3xl blur-2xl pointer-events-none' />
-              
-              {/* Image container with fixed aspect ratio */}
-              <div className='relative aspect-[3/4] w-full'>
-                <Slideshow
-                  name={person.id}
-                  count={imageCount}
-                  aspect='hero'
-                  placeholder={hasPlaceholder}
-                />
-                
-                {/* Cinematic gradient overlays */}
-                <div className='absolute inset-0 bg-gradient-to-t from-black via-black/50 to-transparent z-10' />
-                <div className='absolute inset-0 bg-gradient-to-r from-black/30 via-transparent to-black/30 z-10' />
-                
-                {/* Spotlight effect */}
-                <div className='spotlight' />
-                
-                {/* Film grain overlay */}
-                <div className='grain' />
-                
-                {/* Vignette */}
-                <div className='absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_30%,rgba(0,0,0,0.4)_100%)] z-10 pointer-events-none' />
+
+          <div className='mt-6 grid lg:grid-cols-[1.1fr_0.9fr] gap-6 lg:gap-10 items-end'>
+            <div>
+              <div className='flex flex-wrap items-center gap-2 mb-4'>
+                <span className='inline-flex items-center rounded-full border border-kolping-400/40 bg-site-950/60 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.16em] text-kolping-400 uppercase'>
+                  Profil
+                </span>
+                <span className='inline-flex items-center rounded-full border border-white/20 bg-site-950/55 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.14em] text-site-100 uppercase'>
+                  {typeLabel}
+                </span>
+                {hasRoles && (
+                  <span className='inline-flex items-center rounded-full border border-white/20 bg-site-950/55 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.14em] text-site-100 uppercase'>
+                    Rollenchronik
+                  </span>
+                )}
               </div>
-              
-              {/* Info section below image */}
-              <div className='relative z-20 p-6 sm:p-8 bg-site-800 border-t border-site-700'>
-                {/* Decorative top accent */}
-                <div className='absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2'>
-                  <div className='w-24 h-1 bg-gradient-to-r from-transparent via-kolping-500 to-transparent rounded-full' />
-                </div>
-                
-                <div className='space-y-5'>
-                  {/* Name */}
-                  <div>
-                    <div className='flex items-center gap-3 mb-3'>
-                      <div className='w-12 h-1 bg-gradient-to-r from-kolping-500 via-kolping-400 to-transparent rounded-full' />
-                    </div>
-                    <h1 
-                      className='font-display text-3xl sm:text-4xl md:text-5xl font-black tracking-tight text-site-50 uppercase break-words'
-                      style={{ viewTransitionName: `person-title-${person.id}` }}
-                    >
-                      {person.name ?? person.id}
-                    </h1>
-                  </div>
-                  
-                  {/* Status badges */}
-                  <div className='flex flex-wrap items-center gap-3'>
-                    {/* Member type badge */}
-                    <div className={`
-                      inline-flex items-center gap-2 px-3 py-1.5 rounded-full border
-                      ${personType === 'current' 
-                        ? 'bg-kolping-500/10 border-kolping-500/30 text-kolping-400' 
-                        : personType === 'tech'
-                        ? 'bg-blue-500/10 border-blue-500/30 text-blue-400'
-                        : 'bg-site-700/50 border-site-600 text-site-100'
-                      }
-                    `}>
-                      <svg className='w-4 h-4' fill='currentColor' viewBox='0 0 20 20'>
-                        <path d='M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z' />
-                      </svg>
-                      <span className='text-sm font-semibold'>
-                        {personType === 'current' ? 'Schauspieler/in' 
-                          : personType === 'tech' ? 'Technik & Crew' 
-                          : 'Ehemaliges Mitglied'}
-                      </span>
-                    </div>
-                  </div>
+
+              <h1 className='font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black tracking-tight leading-[0.94] text-shadow-lg'>
+                <span className='text-site-50'>{person.name ?? person.id}</span>
+              </h1>
+
+              <p className='mt-4 sm:mt-6 text-base sm:text-lg text-site-100/90 max-w-2xl leading-relaxed text-shadow'>
+                {personType === 'tech'
+                  ? 'Einblick in Aufgaben hinter den Kulissen und Beiträge zum Gesamtbild jeder Produktion.'
+                  : 'Überblick über Rollen, Auftritte und Stationen auf der Bühne des Kolpingtheaters Ramsen.'}
+              </p>
+            </div>
+
+            <div style={{ viewTransitionName: `person-${person.id}` }}>
+              <div className='relative poster-frame border-epic overflow-hidden'>
+                <div className='relative aspect-[3/4] w-full'>
+                  <Slideshow
+                    name={person.id}
+                    count={imageCount}
+                    aspect='hero'
+                    placeholder={hasPlaceholder}
+                  />
+                  <div className='absolute inset-0 bg-gradient-to-t from-black/50 to-transparent pointer-events-none' />
                 </div>
               </div>
             </div>
@@ -218,118 +220,85 @@ export default async function PersonPage({
         </div>
       </section>
 
-      {/* Content Sections */}
-      <div className='max-w-5xl mx-auto px-4 sm:px-6 space-y-16 sm:space-y-20 pb-16'>
-        
-        {/* Roles Section */}
-        {rolesData.length > 0 && (
-          <section className='space-y-8'>
-            {/* Section header */}
-            <div className='text-center space-y-4'>
-              <div className='flex items-center justify-center gap-4'>
-                <div className='hidden sm:block w-16 h-px bg-gradient-to-r from-transparent to-kolping-500/80' />
-                <div className='relative'>
-                  <div className='absolute -inset-3 bg-kolping-500/10 blur-xl rounded-full' />
-                  <h2 className='relative font-display text-3xl sm:text-4xl md:text-5xl font-black text-kolping-400 drop-shadow-[0_0_20px_rgba(255,122,0,0.3)]'>
-                    Theater-Reise
-                  </h2>
-                </div>
-                <div className='hidden sm:block w-16 h-px bg-gradient-to-l from-transparent to-kolping-500/80' />
-              </div>
-              <p className='text-site-100 text-base sm:text-lg max-w-lg mx-auto'>
-                Eine Chronik der dargestellten Rollen durch die Jahre
-              </p>
+      <section className='mx-auto max-w-6xl px-4 pt-8 sm:pt-10 pb-6 sm:pb-10'>
+        {hasRoles && (
+          <div>
+            <SectionDivider
+              title='Rollenchronik'
+              subtitle='Alle dokumentierten Rollen im zeitlichen Verlauf'
+            />
+            <div className='glass border border-site-700 rounded-2xl p-4 sm:p-6 md:p-8'>
+              <RolesList roles={rolesData} />
             </div>
-            
-            {/* Roles timeline */}
-            <div className='relative'>
-              {/* Decorative corner elements */}
-              <div className='absolute -top-4 -left-4 w-8 h-8 border-l-2 border-t-2 border-kolping-500/30 rounded-tl-lg' />
-              <div className='absolute -top-4 -right-4 w-8 h-8 border-r-2 border-t-2 border-kolping-500/30 rounded-tr-lg' />
-              <div className='absolute -bottom-4 -left-4 w-8 h-8 border-l-2 border-b-2 border-kolping-500/30 rounded-bl-lg' />
-              <div className='absolute -bottom-4 -right-4 w-8 h-8 border-r-2 border-b-2 border-kolping-500/30 rounded-br-lg' />
-              
-              <div className='py-6 px-2 sm:px-4'>
-                <RolesList roles={rolesData} />
-              </div>
-            </div>
-          </section>
+          </div>
         )}
-        
-        {/* Tech & Crew Section */}
-        {person.jobs && person.jobs.length > 0 && (
-          <section className='space-y-8'>
-            {/* Section header */}
-            <div className='text-center space-y-4'>
-              <div className='flex items-center justify-center gap-4'>
-                <div className='hidden sm:block w-16 h-px bg-gradient-to-r from-transparent to-blue-500/80' />
-                <div className='relative'>
-                  <div className='absolute -inset-3 bg-blue-500/10 blur-xl rounded-full' />
-                  <h2 className='relative font-display text-3xl sm:text-4xl md:text-5xl font-black text-blue-400 drop-shadow-[0_0_20px_rgba(59,130,246,0.3)]'>
-                    Hinter den Kulissen
-                  </h2>
-                </div>
-                <div className='hidden sm:block w-16 h-px bg-gradient-to-l from-transparent to-blue-500/80' />
-              </div>
-              <p className='text-site-100 text-base sm:text-lg max-w-lg mx-auto'>
-                Aufgaben in Technik & Crew
-              </p>
-            </div>
-            
-            {/* Jobs grid */}
-            <div className='flex flex-wrap justify-center gap-4 sm:gap-6'>
-              {person.jobs.map((job, i) => (
+
+        {hasJobs && (
+          <div>
+            <SectionDivider
+              title='Aufgaben im Team'
+              subtitle='Beiträge in Technik, Organisation und Produktion'
+            />
+            <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-5'>
+              {person.jobs!.map((job, index) => (
                 <div
-                  key={i}
-                  className='group relative'
-                  style={{ animationDelay: `${i * 100}ms` }}
+                  key={`${job.job}-${index}`}
+                  className='group relative glass border border-site-700 rounded-xl p-5 text-center transition-all duration-300 hover:border-kolping-500/40 hover:bg-site-800/80'
                 >
-                  {/* Card glow */}
-                  <div className='absolute -inset-2 bg-gradient-to-b from-blue-500/20 to-transparent rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl' />
-                  
-                  <div className='relative poster-frame border-epic bg-site-800 p-6 sm:p-8 transition-all duration-500 hover:scale-105 hover:-translate-y-2'>
-                    {/* Inner spotlight */}
-                    <div className='absolute inset-0 bg-gradient-to-br from-blue-500/5 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-xl' />
-                    
-                    <div className='relative flex flex-col items-center gap-4 text-center'>
-                      {/* Icon */}
-                      <div className='relative'>
-                        <div className='absolute -inset-2 bg-blue-500/20 rounded-full blur-lg opacity-0 group-hover:opacity-100 transition-opacity duration-500' />
-                        <JobIcon icon={job.icon} />
-                      </div>
-                      
-                      {/* Job title */}
-                      <span className='font-display font-bold text-lg sm:text-xl text-site-50 group-hover:text-blue-400 transition-colors duration-300'>
-                        {job.job}
-                      </span>
-                    </div>
-                    
-                    {/* Bottom accent */}
-                    <div className='absolute bottom-0 left-1/2 -translate-x-1/2 w-16 h-0.5 bg-gradient-to-r from-transparent via-blue-500 to-transparent opacity-0 group-hover:opacity-60 transition-opacity duration-500' />
+                  <div className='absolute -inset-3 bg-kolping-500/10 rounded-2xl blur-xl opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none' />
+                  <div className='relative space-y-3'>
+                    <JobIcon icon={job.icon} />
+                    <p className='text-sm sm:text-base font-semibold text-site-50 group-hover:text-kolping-400 transition-colors'>
+                      {job.job}
+                    </p>
                   </div>
                 </div>
               ))}
             </div>
-          </section>
+          </div>
         )}
-        
-        {/* Empty state for new members */}
-        {rolesData.length === 0 && (!person.jobs || person.jobs.length === 0) && (
-          <section className='text-center py-12'>
-            <div className='inline-flex items-center justify-center w-20 h-20 rounded-full bg-site-900 border border-site-700 mb-6'>
-              <svg className='w-10 h-10 text-kolping-400' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
+
+        {!hasRoles && !hasJobs && (
+          <div className='py-14 text-center'>
+            <div className='inline-flex items-center justify-center w-16 h-16 rounded-full bg-site-800 border border-site-700 mb-5'>
+              <svg className='w-8 h-8 text-kolping-400' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
                 <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1.5} d='M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z' />
               </svg>
             </div>
-            <h3 className='font-display text-2xl font-bold text-site-50 mb-3'>
-              Ein neuer Stern am Theaterhimmel
-            </h3>
-            <p className='text-site-100 max-w-md mx-auto'>
-              Die Bühne wartet! Bald werden hier die ersten Rollen und Auftritte zu sehen sein.
+            <h2 className='font-display text-2xl sm:text-3xl font-bold text-site-50'>
+              Neue Stationen folgen
+            </h2>
+            <p className='mt-2 text-site-100 max-w-md mx-auto'>
+              Für dieses Profil sind aktuell noch keine Rollen oder Aufgaben veröffentlicht.
             </p>
-          </section>
+          </div>
         )}
-      </div>
+      </section>
+
+      <section className='mx-auto max-w-6xl px-4 pb-12 sm:pb-16'>
+        <div className='relative overflow-hidden rounded-2xl border border-site-700'>
+          <div className='absolute inset-0 bg-gradient-to-br from-kolping-400/10 via-site-900 to-site-900' />
+          <div className='relative p-6 sm:p-8 md:p-10 flex flex-col sm:flex-row items-center justify-between gap-4'>
+            <p className='text-sm sm:text-base text-site-100 text-center sm:text-left'>
+              Mehr vom Ensemble oder direkt in die Galerie wechseln.
+            </p>
+            <div className='flex items-center gap-3'>
+              <Link
+                href='/team'
+                className='inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/60 px-5 py-2.5 text-sm font-medium transition-all hover:border-kolping-400/50 hover:bg-site-800'
+              >
+                Teamübersicht
+              </Link>
+              <Link
+                href='/gallery'
+                className='inline-flex items-center gap-2 rounded-full bg-kolping-400 px-5 py-2.5 text-sm font-bold text-white transition-all hover:bg-kolping-500'
+              >
+                Zur Galerie
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/app/team/[person]/slideshow.tsx
+++ b/src/app/team/[person]/slideshow.tsx
@@ -7,18 +7,14 @@ export default function Slideshow({
   name,
   count,
   aspect = 'hero',
-  placeholder = false,
 }: {
   name: string
   count: number
   aspect?: 'portrait' | 'landscape' | 'hero'
-  placeholder?: boolean
 }) {
   const images = useMemo(() => {
     const list: string[] = []
-    if (placeholder) {
-      list.push(`/img/team/avatar/placeholder.svg`)
-    } else if (count && count > 0) {
+    if (count && count > 0) {
       for (let i = 1; i <= count; i++) {
         const suffix = i === 1 ? '' : String(i)
         list.push(`/img/team/avatar/${name}${suffix}.jpg`)
@@ -27,7 +23,7 @@ export default function Slideshow({
       list.push(`/img/team/avatar/${name}.jpg`)
     }
     return list
-  }, [name, count, placeholder])
+  }, [name, count])
 
   const [index, setIndex] = useState(0)
   const [isTransitioning, setIsTransitioning] = useState(false)

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -95,11 +95,6 @@ function TeamCard({
             className={`${isPlaceholder ? 'object-contain p-8 opacity-90 group-hover:scale-105' : 'object-cover group-hover:scale-110 group-hover:brightness-110'} transition-all duration-700 ease-out ${isFormer ? 'filter sepia-[0.25] grayscale-[0.25] group-hover:sepia-[0.1] group-hover:grayscale-[0]' : ''}`}
             style={{ viewTransitionName: `person-image-${person.id}` }}
           />
-          {isPlaceholder && (
-            <div className='absolute top-3 right-3 z-20 rounded-full border border-site-700 bg-site-900/85 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-site-100'>
-              Kein Foto
-            </div>
-          )}
           <div className='absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-black via-black/65 to-transparent z-10' />
           <div className='absolute inset-0 bg-gradient-to-r from-black/15 via-transparent to-black/20 z-10' />
 
@@ -194,22 +189,6 @@ export default function TeamPage() {
                 Technik und Organisation arbeiten bei uns als eingespieltes
                 Ensemble.
               </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className='relative -mx-4 border-y border-site-700 bg-site-900'>
-        <div className='mx-auto max-w-6xl px-4 py-5 sm:py-6'>
-          <div className='grid sm:grid-cols-3 gap-3 sm:gap-4'>
-            <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
-              Bühne: Aktuelle Rollen und Darsteller im Ensemble.
-            </div>
-            <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
-              Crew: Technik, Licht, Ton und Ablauf hinter den Kulissen.
-            </div>
-            <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
-              Geschichte: Ehemalige Mitglieder als Teil unserer Theaterreise.
             </div>
           </div>
         </div>

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -156,8 +156,6 @@ export default function TeamPage() {
   const tech = data.tech
   const former = data.former
 
-  const totalPeople = current.length + tech.length + former.length
-
   return (
     <div className='space-y-0'>
       <section className='relative -mx-4 -mt-8 overflow-hidden'>
@@ -202,39 +200,16 @@ export default function TeamPage() {
       </section>
 
       <section className='relative -mx-4 border-y border-site-700 bg-site-900'>
-        <div className='mx-auto max-w-6xl px-4 py-6 sm:py-8'>
-          <div className='grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-8 text-center'>
-            <div>
-              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
-                {current.length}
-              </div>
-              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
-                Aktuell
-              </div>
+        <div className='mx-auto max-w-6xl px-4 py-5 sm:py-6'>
+          <div className='grid sm:grid-cols-3 gap-3 sm:gap-4'>
+            <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
+              Bühne: Aktuelle Rollen und Darsteller im Ensemble.
             </div>
-            <div>
-              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
-                {tech.length}
-              </div>
-              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
-                Crew
-              </div>
+            <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
+              Crew: Technik, Licht, Ton und Ablauf hinter den Kulissen.
             </div>
-            <div>
-              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
-                {former.length}
-              </div>
-              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
-                Ehemalig
-              </div>
-            </div>
-            <div>
-              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
-                {totalPeople}
-              </div>
-              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
-                Gesamt
-              </div>
+            <div className='rounded-lg border border-site-700 bg-site-800/60 px-4 py-3 text-sm text-site-100'>
+              Geschichte: Ehemalige Mitglieder als Teil unserer Theaterreise.
             </div>
           </div>
         </div>
@@ -244,9 +219,9 @@ export default function TeamPage() {
         <div className='sticky top-[72px] z-20 backdrop-blur supports-[backdrop-filter]:bg-site-900/55 bg-site-900/75 rounded-xl border border-site-700/60 p-3'>
           <div className='flex items-center gap-2 overflow-x-auto scrollbar-thin'>
             {[
-              { id: 'team-current', label: 'Aktuelle Mitglieder', count: current.length },
-              { id: 'team-tech', label: 'Technik & Crew', count: tech.length },
-              { id: 'team-former', label: 'Ehemalige Mitglieder', count: former.length },
+              { id: 'team-current', label: 'Aktuelle Mitglieder' },
+              { id: 'team-tech', label: 'Technik & Crew' },
+              { id: 'team-former', label: 'Ehemalige Mitglieder' },
             ].map((section) => (
               <a
                 key={section.id}
@@ -254,9 +229,6 @@ export default function TeamPage() {
                 className='shrink-0 inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/80 px-3 py-1.5 text-xs text-site-100 hover:border-kolping-400/60 hover:text-kolping-400 transition-colors'
               >
                 <span className='font-semibold'>{section.label}</span>
-                <span className='inline-flex min-w-5 h-5 items-center justify-center rounded-full bg-site-700 text-[10px] text-site-100'>
-                  {section.count}
-                </span>
               </a>
             ))}
           </div>

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -61,6 +61,7 @@ function TeamCard({
   index: number
 }) {
   const isFormer = type === 'former'
+  const isPlaceholder = !!person.placeholderAvatar
   const label = type === 'tech' ? 'Crew' : type === 'former' ? 'Ehemalig' : 'Ensemble'
   const roleText =
     type === 'tech'
@@ -86,14 +87,19 @@ function TeamCard({
           {label}
         </div>
 
-        <div className='relative aspect-[3/4] overflow-hidden bg-site-800'>
+        <div className='relative aspect-[3/4] overflow-hidden bg-gradient-to-br from-site-800 to-site-900'>
           <Image
             src={person.placeholderAvatar ? '/img/team/avatar/placeholder.svg' : avatarPath(person.id)}
             alt={person.name ?? person.id}
             fill
-            className={`object-cover transition-all duration-700 ease-out group-hover:scale-110 group-hover:brightness-110 ${isFormer ? 'filter sepia-[0.25] grayscale-[0.25] group-hover:sepia-[0.1] group-hover:grayscale-[0]' : ''}`}
+            className={`${isPlaceholder ? 'object-contain p-8 opacity-90 group-hover:scale-105' : 'object-cover group-hover:scale-110 group-hover:brightness-110'} transition-all duration-700 ease-out ${isFormer ? 'filter sepia-[0.25] grayscale-[0.25] group-hover:sepia-[0.1] group-hover:grayscale-[0]' : ''}`}
             style={{ viewTransitionName: `person-image-${person.id}` }}
           />
+          {isPlaceholder && (
+            <div className='absolute top-3 right-3 z-20 rounded-full border border-site-700 bg-site-900/85 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-site-100'>
+              Kein Foto
+            </div>
+          )}
           <div className='absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-black via-black/65 to-transparent z-10' />
           <div className='absolute inset-0 bg-gradient-to-r from-black/15 via-transparent to-black/20 z-10' />
 

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -9,23 +9,21 @@ type Person = {
   placeholderAvatar?: boolean
 }
 
-function avatarPath(id: string) {
-  const filename = `${id}.jpg`
-  return `/img/team/avatar/${filename}`
+type TeamDataShape = {
+  current: Person[]
+  former: Person[]
+  tech: Person[]
 }
 
-// Section Divider with theatrical curtain effect
+function avatarPath(id: string) {
+  return `/img/team/avatar/${id}.jpg`
+}
+
 function SectionDivider({ title, subtitle }: { title: string; subtitle?: string }) {
   return (
     <div className='relative py-8 sm:py-12'>
-      {/* Curtain drape decoration */}
-      <div className='absolute inset-0 overflow-hidden pointer-events-none'>
-        <div className='absolute top-0 left-1/2 -translate-x-1/2 w-[200%] h-16' />
-      </div>
-
       <div className='relative text-center space-y-3'>
         <div className='flex items-center justify-center gap-4'>
-          {/* Left decorative flourish */}
           <div className='hidden sm:flex items-center gap-2'>
             <div className='w-8 h-px bg-gradient-to-l from-kolping-500 to-transparent' />
             <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
@@ -36,7 +34,6 @@ function SectionDivider({ title, subtitle }: { title: string; subtitle?: string 
             {title}
           </h2>
 
-          {/* Right decorative flourish */}
           <div className='hidden sm:flex items-center gap-2'>
             <div className='w-16 h-px bg-gradient-to-r from-kolping-500/80 to-transparent' />
             <div className='w-2 h-2 rotate-45 bg-kolping-500/60' />
@@ -45,7 +42,7 @@ function SectionDivider({ title, subtitle }: { title: string; subtitle?: string 
         </div>
 
         {subtitle && (
-          <p className='text-site-100 text-sm sm:text-base max-w-lg mx-auto'>
+          <p className='text-site-100 text-sm sm:text-base max-w-xl mx-auto'>
             {subtitle}
           </p>
         )}
@@ -54,215 +51,271 @@ function SectionDivider({ title, subtitle }: { title: string; subtitle?: string 
   )
 }
 
-// Theatrical person card
-function PersonCard({
+function TeamCard({
   person,
   type,
-  index
+  index,
 }: {
   person: Person
-  type: 'current' | 'former' | 'tech'
+  type: 'current' | 'tech' | 'former'
   index: number
 }) {
   const isFormer = type === 'former'
-  const isTech = type === 'tech'
+  const label = type === 'tech' ? 'Crew' : type === 'former' ? 'Ehemalig' : 'Ensemble'
+  const roleText =
+    type === 'tech'
+      ? 'Technik & Organisation'
+      : type === 'former'
+        ? 'Ehemaliges Mitglied'
+        : 'Schauspiel & Bühne'
 
   return (
     <Link
       href={`/team/${encodeURIComponent(person.id)}`}
       className='group relative block'
-      aria-label={`Profil von ${person.name ?? person.id} ansehen${isFormer ? ' (ehemalig)' : ''}`}
-      style={{
-        viewTransitionName: `person-${person.id}`,
-        animationDelay: `${index * 50}ms`,
-      }}
+      aria-label={`Profil von ${person.name ?? person.id} ansehen`}
+      style={{ viewTransitionName: `person-${person.id}` }}
     >
-      {/* Card container with epic glow */}
-      <div className={`
-        relative poster-frame border-epic bg-site-800 
-        transition-all duration-500 ease-out
-        hover:scale-[1.03] hover:-translate-y-2
-        animate-fade-in-up
-        ${isFormer ? 'opacity-85 hover:opacity-100' : ''}
-      `}>
-        {/* Theatrical spotlight glow on hover */}
+      <div
+        className={`relative poster-frame border-epic bg-site-800 transition-all duration-500 ease-out hover:scale-[1.03] hover:-translate-y-2 animate-fade-in-up ${isFormer ? 'opacity-85 hover:opacity-100' : ''}`}
+        style={{ animationDelay: `${index * 35}ms` }}
+      >
         <div className='absolute -inset-4 bg-gradient-to-b from-kolping-500/20 via-kolping-500/5 to-transparent rounded-3xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl pointer-events-none' />
 
-        {/* Image container */}
-        <div className='relative aspect-[3/4] overflow-hidden bg-site-800'>
-          {/* Animated spotlight beam */}
-          <div className='absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-700 pointer-events-none z-10'>
-            <div className='absolute top-0 left-1/2 -translate-x-1/2 w-full h-full bg-gradient-to-b from-kolping-500/20 via-transparent to-transparent' />
-          </div>
+        <div className='absolute top-3 left-3 z-30 rounded-full border border-site-700 bg-site-900/85 backdrop-blur-sm px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.15em] text-kolping-400'>
+          {label}
+        </div>
 
+        <div className='relative aspect-[3/4] overflow-hidden bg-site-800'>
           <Image
-            src={
-              person.placeholderAvatar
-                ? '/img/team/avatar/placeholder.svg'
-                : avatarPath(person.id)
-            }
+            src={person.placeholderAvatar ? '/img/team/avatar/placeholder.svg' : avatarPath(person.id)}
             alt={person.name ?? person.id}
             fill
-            className={`
-              object-cover transition-all duration-700 ease-out
-              group-hover:scale-110 group-hover:brightness-110
-              ${isFormer ? 'filter sepia-[0.3] grayscale-[0.2] group-hover:sepia-[0.1] group-hover:grayscale-[0]' : ''}
-            `}
-            style={{
-              viewTransitionName: `person-image-${person.id}`,
-            }}
+            className={`object-cover transition-all duration-700 ease-out group-hover:scale-110 group-hover:brightness-110 ${isFormer ? 'filter sepia-[0.25] grayscale-[0.25] group-hover:sepia-[0.1] group-hover:grayscale-[0]' : ''}`}
+            style={{ viewTransitionName: `person-image-${person.id}` }}
           />
+          <div className='absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-black via-black/65 to-transparent z-10' />
+          <div className='absolute inset-0 bg-gradient-to-r from-black/15 via-transparent to-black/20 z-10' />
 
-          {/* Dramatic gradient overlays */}
-          <div className='absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black via-black/60 to-transparent z-10' />
-          <div className='absolute inset-0 bg-gradient-to-r from-black/20 via-transparent to-black/20 z-10' />
-
-          {/* Type badge */}
-          {isTech && (
-            <div className='absolute top-3 right-3 z-20'>
-              <div className='px-2.5 py-1 rounded-full bg-black/70 backdrop-blur-sm border border-kolping-500/40'>
-                <span className='text-[10px] font-bold uppercase tracking-wider text-kolping-400'>Crew</span>
-              </div>
-            </div>
-          )}
-
-          {/* Name overlay on image */}
-          <div className='absolute bottom-0 inset-x-0 p-4 z-20'>
+          <div className='absolute inset-x-0 bottom-0 p-4 z-20'>
             <h3 className='font-display font-bold text-lg sm:text-xl text-white group-hover:text-kolping-400 transition-colors duration-300 drop-shadow-lg'>
               {person.name ?? person.id}
             </h3>
-            <div className='flex items-center gap-2 mt-1'>
+            <div className='mt-1 flex items-center gap-2'>
               <div className='w-6 h-0.5 bg-kolping-500 rounded-full transition-all duration-500 group-hover:w-12' />
-              <span className='text-xs text-white/70 font-medium'>
-                {isFormer ? 'Ehemaliges Mitglied' : isTech ? 'Technik & Crew' : 'Schauspieler/in'}
-              </span>
+              <span className='text-xs text-white/75 font-medium'>{roleText}</span>
             </div>
           </div>
         </div>
 
-        {/* Bottom accent bar */}
         <div className='h-1 bg-gradient-to-r from-transparent via-kolping-500/50 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500' />
       </div>
     </Link>
   )
 }
 
+function TeamSection({
+  id,
+  title,
+  subtitle,
+  people,
+  type,
+}: {
+  id: string
+  title: string
+  subtitle: string
+  people: Person[]
+  type: 'current' | 'tech' | 'former'
+}) {
+  return (
+    <section id={id} className='scroll-mt-32'>
+      <SectionDivider title={title} subtitle={subtitle} />
+      <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6'>
+        {people.map((person, index) => (
+          <TeamCard
+            key={person.id}
+            person={person}
+            type={type}
+            index={index}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
 export default function TeamPage() {
-  const current: Person[] = (teamData as unknown as { current: Person[] })
-    .current
-  const former: Person[] = (teamData as unknown as { former: Person[] }).former
-  const tech: {
-    id: string
-    name?: string
-    placeholderAvatar?: boolean
-    jobs?: { job: string; icon?: string }[]
-    images?: number
-  }[] = (
-    teamData as unknown as {
-      tech: {
-        id: string
-        name?: string
-        placeholderAvatar?: boolean
-        jobs?: { job: string; icon?: string }[]
-        images?: number
-      }[]
-    }
-  ).tech
+  const data = teamData as TeamDataShape
+  const current = data.current
+  const tech = data.tech
+  const former = data.former
+
+  const totalPeople = current.length + tech.length + former.length
 
   return (
-    <div className='space-y-8 sm:space-y-12 md:space-y-16'>
-      {/* Epic Hero Section */}
-      <section className='relative -mt-8 pt-8 pb-12 sm:pb-16 overflow-hidden'>
-        {/* Background theatrical elements */}
-        <div className='absolute inset-0 pointer-events-none'>
-          {/* Stage spotlights */}
-          <div className='absolute top-0 left-1/4 w-96 h-96 bg-gradient-radial from-kolping-500/10 to-transparent blur-3xl' />
-          <div className='absolute top-0 right-1/4 w-96 h-96 bg-gradient-radial from-kolping-500/10 to-transparent blur-3xl' />
+    <div className='space-y-0'>
+      <section className='relative -mx-4 -mt-8 overflow-hidden'>
+        <div className='relative w-full h-[72vh] min-h-[460px] max-h-[820px]'>
+          <Image
+            src='/img/team/team_header.jpg'
+            alt='Team des Kolpingtheaters Ramsen'
+            fill
+            priority
+            sizes='100vw'
+            className='object-cover'
+          />
+          <div className='absolute inset-0 bg-gradient-to-b from-site-950/35 via-site-950/25 to-site-950' />
+          <div className='absolute inset-0 bg-gradient-to-r from-site-950/55 via-transparent to-site-950/35' />
+          <div className='vignette' />
 
-        </div>
+          <div className='absolute inset-0 flex flex-col justify-end pb-10 sm:pb-14 md:pb-16'>
+            <div className='mx-auto w-full max-w-6xl px-4'>
+              <div className='animate-fade-in-up mb-4 flex flex-wrap gap-2.5'>
+                <span className='inline-flex items-center rounded-full border border-kolping-400/40 bg-site-950/60 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.16em] text-kolping-400 uppercase'>
+                  Team & Crew
+                </span>
+                <span className='inline-flex items-center rounded-full border border-white/20 bg-site-950/55 backdrop-blur-sm px-3 py-1 text-[11px] font-semibold tracking-[0.14em] text-site-100 uppercase'>
+                  Bühne, Technik, Organisation
+                </span>
+              </div>
 
-        <div className='relative text-center space-y-6'>
-          {/* Decorative top element */}
-          <div className='flex justify-center'>
-            <div className='relative'>
-              <div className='absolute -inset-4 bg-kolping-500/20 blur-2xl rounded-full' />
-              <svg className='relative w-12 h-12 text-kolping-500' fill='none' viewBox='0 0 24 24' stroke='currentColor'>
-                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1} d='M15 12a3 3 0 11-6 0 3 3 0 016 0z' />
-                <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={1} d='M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z' />
-              </svg>
+              <h1 className='animate-fade-in-up font-display text-4xl sm:text-6xl md:text-7xl lg:text-8xl font-black tracking-tight leading-[0.92] text-shadow-lg'>
+                Unser Team
+                <br />
+                <span className='text-kolping-400'>Kolpingtheater Ramsen</span>
+              </h1>
+
+              <p className='animate-fade-in-up mt-4 sm:mt-6 text-base sm:text-lg md:text-xl text-site-100/90 max-w-2xl leading-relaxed text-shadow'>
+                Hinter jeder Produktion stehen viele Gesichter. Schauspiel,
+                Technik und Organisation arbeiten bei uns als eingespieltes
+                Ensemble.
+              </p>
             </div>
           </div>
-
-          <h1 className='font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black tracking-tight'>
-            <span className='text-kolping-400 drop-shadow-[0_0_30px_rgba(255,122,0,0.4)]'>Unser</span>{' '}
-            <span className='text-site-50'>Team</span>
-          </h1>
-
-          <p className='text-site-100 text-base sm:text-lg max-w-2xl mx-auto leading-relaxed'>
-            Die talentierten Köpfe hinter unseren unvergesslichen Aufführungen.
-            <span className='text-kolping-400'> Schauspieler, Techniker und Kreative</span> –
-            vereint durch die Leidenschaft für das Theater.
-          </p>
         </div>
       </section>
 
-      {/* Current Members */}
-      <section>
-        <SectionDivider
-          title="Aktuelle Mitglieder"
-          subtitle="Das Herzstück unserer Bühne"
-        />
-        <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6'>
-          {current.map((person, index) => (
-            <PersonCard
-              key={person.id}
-              person={person}
-              type="current"
-              index={index}
-            />
-          ))}
+      <section className='relative -mx-4 border-y border-site-700 bg-site-900'>
+        <div className='mx-auto max-w-6xl px-4 py-6 sm:py-8'>
+          <div className='grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-8 text-center'>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {current.length}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Aktuell
+              </div>
+            </div>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {tech.length}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Crew
+              </div>
+            </div>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {former.length}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Ehemalig
+              </div>
+            </div>
+            <div>
+              <div className='font-display text-2xl sm:text-3xl md:text-4xl font-black text-kolping-400'>
+                {totalPeople}
+              </div>
+              <div className='mt-1 text-[11px] sm:text-xs tracking-[0.15em] uppercase text-site-100'>
+                Gesamt
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 
-      {/* Tech & Crew */}
-      <section>
-        <SectionDivider
-          title="Technik & Crew"
-          subtitle="Die Magie hinter der Bühne"
-        />
-        <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6'>
-          {tech.map((person, index) => (
-            <PersonCard
-              key={person.id}
-              person={person}
-              type="tech"
-              index={index}
-            />
-          ))}
-        </div>
-      </section>
-
-      {/* Former Members */}
-      <section className='relative'>
-        {/* Subtle vignette for nostalgic feel */}
-        <div className='absolute inset-0 pointer-events-none'>
-          <div className='absolute inset-0 bg-gradient-to-t from-site-950/50 via-transparent to-site-950/50' />
-        </div>
-
-        <div className='relative'>
-          <SectionDivider
-            title="Ehemalige Mitglieder"
-            subtitle="Mit Dankbarkeit erinnern wir uns an ihre Beiträge"
-          />
-          <div className='grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4 sm:gap-6'>
-            {former.map((person, index) => (
-              <PersonCard
-                key={person.id}
-                person={person}
-                type="former"
-                index={index}
-              />
+      <section className='mx-auto max-w-6xl px-4 pt-6 sm:pt-8 pb-4'>
+        <div className='sticky top-[72px] z-20 backdrop-blur supports-[backdrop-filter]:bg-site-900/55 bg-site-900/75 rounded-xl border border-site-700/60 p-3'>
+          <div className='flex items-center gap-2 overflow-x-auto scrollbar-thin'>
+            {[
+              { id: 'team-current', label: 'Aktuelle Mitglieder', count: current.length },
+              { id: 'team-tech', label: 'Technik & Crew', count: tech.length },
+              { id: 'team-former', label: 'Ehemalige Mitglieder', count: former.length },
+            ].map((section) => (
+              <a
+                key={section.id}
+                href={`#${section.id}`}
+                className='shrink-0 inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/80 px-3 py-1.5 text-xs text-site-100 hover:border-kolping-400/60 hover:text-kolping-400 transition-colors'
+              >
+                <span className='font-semibold'>{section.label}</span>
+                <span className='inline-flex min-w-5 h-5 items-center justify-center rounded-full bg-site-700 text-[10px] text-site-100'>
+                  {section.count}
+                </span>
+              </a>
             ))}
+          </div>
+        </div>
+      </section>
+
+      <div className='mx-auto max-w-6xl px-4 pb-6 sm:pb-10 space-y-10 sm:space-y-14'>
+        <TeamSection
+          id='team-current'
+          title='Aktuelle Mitglieder'
+          subtitle='Das Ensemble, das die aktuellen Produktionen trägt'
+          people={current}
+          type='current'
+        />
+        <TeamSection
+          id='team-tech'
+          title='Technik & Crew'
+          subtitle='Die Menschen hinter Licht, Ton, Bühnenbild und Ablauf'
+          people={tech}
+          type='tech'
+        />
+        <TeamSection
+          id='team-former'
+          title='Ehemalige Mitglieder'
+          subtitle='Mit Dankbarkeit für viele Jahre gemeinsamer Theaterarbeit'
+          people={former}
+          type='former'
+        />
+      </div>
+
+      <section className='mx-auto max-w-6xl px-4 py-12 sm:py-16'>
+        <div className='relative overflow-hidden rounded-2xl border border-site-700'>
+          <div className='absolute inset-0 bg-gradient-to-br from-kolping-400/10 via-site-900 to-site-900' />
+          <div className='absolute top-0 right-0 w-1/2 h-full bg-gradient-to-l from-kolping-400/[0.05] to-transparent' />
+
+          <div className='relative p-8 sm:p-10 md:p-14 flex flex-col md:flex-row items-center gap-8 md:gap-12'>
+            <div className='flex-1 text-center md:text-left'>
+              <span className='block text-[11px] sm:text-xs tracking-[0.2em] uppercase text-kolping-400 font-semibold mb-3'>
+                Mitmachen
+              </span>
+              <h2 className='font-display text-2xl sm:text-3xl md:text-4xl font-black tracking-tight leading-tight'>
+                Du willst dabei sein?
+              </h2>
+              <p className='text-site-100 mt-3 sm:mt-4 text-sm sm:text-base max-w-md leading-relaxed'>
+                Wenn du Lust auf Bühne, Technik oder Organisation hast, freuen
+                wir uns auf deine Nachricht.
+              </p>
+            </div>
+            <div className='flex flex-col sm:flex-row items-center gap-3'>
+              <Link
+                href='/contact'
+                className='group inline-flex items-center gap-2.5 rounded-full bg-kolping-400 px-6 py-3 text-sm font-bold text-white transition-all hover:bg-kolping-500 hover:shadow-[0_0_30px_rgba(255,122,0,0.3)]'
+              >
+                Kontakt
+                <svg className='w-4 h-4 transition-transform group-hover:translate-x-0.5' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                  <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M9 5l7 7-7 7' />
+                </svg>
+              </Link>
+              <Link
+                href='/gallery'
+                className='inline-flex items-center gap-2 rounded-full border border-site-700 bg-site-800/50 px-6 py-3 text-sm font-medium transition-all hover:border-kolping-400/50 hover:bg-site-800'
+              >
+                Produktionen ansehen
+              </Link>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- redesign `/about` with a cinematic, home-page-aligned hero and modern section flow
- add dynamic stats ribbon derived from existing team/play data
- add generic group information cards with updated CTAs
- preserve full timeline while improving visual hierarchy and card presentation
- add closing join/contact CTA section consistent with index page language

## Validation
- `pnpm lint`
- `pnpm build`
- `pnpm exec next lint --file src/app/about/page.tsx`

## Notes
- left pre-existing unrelated local changes in `src/data/images.json` out of this commit/PR
